### PR TITLE
FFT::Radix2 uses bit-reversed permutation algorithm

### DIFF
--- a/documentation/references.bib
+++ b/documentation/references.bib
@@ -41,3 +41,9 @@
     month     = {Jan},
     isbn      = {9782729852184}
 }
+
+@book{primenumbers,
+    author = {Richard Crandall and Carl Pomerance and Richard Crandall and Carl Pomerance},
+    title = {Prime numbers: a computational perspective. Second Edition},
+    year = {2005}
+}

--- a/src/fec_base.h
+++ b/src/fec_base.h
@@ -164,8 +164,8 @@ class FecCode {
     bool readw(T* ptr, std::istream* stream);
     bool writew(T val, std::ostream* stream);
 
-    bool read_pkt(char* pkt, std::istream* stream);
-    bool write_pkt(char* pkt, std::ostream* stream);
+    bool read_pkt(char* pkt, std::istream& stream);
+    bool write_pkt(char* pkt, std::ostream& stream);
 
     void encode_bufs(
         std::vector<std::istream*> input_data_bufs,
@@ -362,18 +362,18 @@ inline bool FecCode<T>::writew(T val, std::ostream* stream)
 }
 
 template <typename T>
-inline bool FecCode<T>::read_pkt(char* pkt, std::istream* stream)
+inline bool FecCode<T>::read_pkt(char* pkt, std::istream& stream)
 {
-    if (stream->read(pkt, buf_size)) {
+    if (stream.read(pkt, buf_size)) {
         return true;
     }
     return false;
 }
 
 template <typename T>
-inline bool FecCode<T>::write_pkt(char* pkt, std::ostream* stream)
+inline bool FecCode<T>::write_pkt(char* pkt, std::ostream& stream)
 {
-    if (stream->write(pkt, buf_size))
+    if (stream.write(pkt, buf_size))
         return true;
     return false;
 }
@@ -476,7 +476,8 @@ void FecCode<T>::encode_packet(
     while (true) {
         // TODO: get number of read bytes -> true buf size
         for (unsigned i = 0; i < n_data; i++) {
-            if (!read_pkt((char*)(words_mem_char.at(i)), input_data_bufs[i])) {
+            if (!read_pkt(
+                    (char*)(words_mem_char.at(i)), *(input_data_bufs[i]))) {
                 cont = false;
                 break;
             }
@@ -501,7 +502,8 @@ void FecCode<T>::encode_packet(
             output_mem_T, output_mem_char, output_len, pkt_size, word_size);
 
         for (unsigned i = 0; i < n_outputs; i++) {
-            write_pkt((char*)(output_mem_char.at(i)), output_parities_bufs[i]);
+            write_pkt(
+                (char*)(output_mem_char.at(i)), *(output_parities_bufs[i]));
         }
         offset += buf_size;
     }
@@ -945,7 +947,7 @@ bool FecCode<T>::decode_packet(
                 unsigned data_idx = fragments_ids.get(i);
                 if (!read_pkt(
                         (char*)(words_mem_char.at(i)),
-                        input_data_bufs[data_idx])) {
+                        *(input_data_bufs[data_idx]))) {
                     cont = false;
                     break;
                 }
@@ -955,7 +957,7 @@ bool FecCode<T>::decode_packet(
             unsigned parity_idx = avail_parity_ids.get(i);
             if (!read_pkt(
                     (char*)(words_mem_char.at(avail_data_nb + i)),
-                    input_parities_bufs[parity_idx])) {
+                    *(input_parities_bufs[parity_idx]))) {
                 cont = false;
                 break;
             }
@@ -982,7 +984,8 @@ bool FecCode<T>::decode_packet(
 
         for (unsigned i = 0; i < n_data; i++) {
             if (output_data_bufs[i] != nullptr) {
-                write_pkt((char*)(output_mem_char.at(i)), output_data_bufs[i]);
+                write_pkt(
+                    (char*)(output_mem_char.at(i)), *(output_data_bufs[i]));
             }
         }
         offset += buf_size;

--- a/src/fec_base.h
+++ b/src/fec_base.h
@@ -216,7 +216,6 @@ class FecCode {
     T r;
     std::unique_ptr<gf::Field<T>> gf = nullptr;
     std::unique_ptr<fft::FourierTransform<T>> fft = nullptr;
-    std::unique_ptr<fft::FourierTransform<T>> fft_full = nullptr;
     std::unique_ptr<fft::FourierTransform<T>> fft_2k = nullptr;
     // This vector MUST be initialized by derived Class using multiplicative FFT
     std::unique_ptr<vec::Vector<T>> inv_r_powers = nullptr;
@@ -736,9 +735,6 @@ FecCode<T>::init_context_dec(vec::Vector<T>& fragments_ids, size_t size)
     if (this->fft == nullptr) {
         throw LogicError("FEC base: FFT must be initialized");
     }
-    if (this->fft_full == nullptr) {
-        throw LogicError("FEC base: FFT full must be initialized");
-    }
 
     int k = this->n_data; // number of fragments received
     // vector x=(x_0, x_1, ..., x_k-1)
@@ -814,7 +810,7 @@ void FecCode<T>::decode_apply(
     }
 
     // compute vec2_n = FFT(vec1_n)
-    this->fft_full->fft_inv(vec2_n, vec1_n);
+    this->fft->fft_inv(vec2_n, vec1_n);
 
     // vec_tmp_2k: first k elements from vec2_n
     //             last (len_2k - k) elements are padded
@@ -1103,7 +1099,7 @@ void FecCode<T>::decode_apply(
     }
 
     // compute buf2_n
-    this->fft_full->fft_inv(buf2_n, buf1_n);
+    this->fft->fft_inv(buf2_n, buf1_n);
 
     // buf1_2k: first k buffers point to first k buffers of buf2_n
     //          las k buffers point to a padded zero buffer

--- a/src/fec_rs_fnt.h
+++ b/src/fec_rs_fnt.h
@@ -140,8 +140,7 @@ class RsFnt : public FecCode<T> {
         off_t offset,
         vec::Vector<T>& words) override
     {
-        vec::ZeroExtended<T> vwords(words, this->n);
-        this->fft->fft(output, vwords);
+        this->fft->fft(output, words);
         // max_value = 2^x
         T thres = this->gf->card() - 1;
         // check for out of range value in output
@@ -159,8 +158,7 @@ class RsFnt : public FecCode<T> {
         off_t offset,
         vec::Buffers<T>& words) override
     {
-        vec::BuffersZeroExtended<T> vwords(words, this->n);
-        this->fft->fft(output, vwords);
+        this->fft->fft(output, words);
         // check for out of range value in output
         int size = output.get_size();
         T thres = (this->gf->card() - 1);

--- a/src/fec_rs_fnt.h
+++ b/src/fec_rs_fnt.h
@@ -99,9 +99,6 @@ class RsFnt : public FecCode<T> {
         this->fft = std::unique_ptr<fft::Radix2<T>>(
             new fft::Radix2<T>(*(this->gf), this->n, m, this->pkt_size));
 
-        this->fft_full = std::unique_ptr<fft::Radix2<T>>(
-            new fft::Radix2<T>(*(this->gf), this->n, this->n, this->pkt_size));
-
         unsigned len_2k = this->gf->get_code_len_high_compo(2 * this->n_data);
         this->fft_2k = std::unique_ptr<fft::Radix2<T>>(
             new fft::Radix2<T>(*(this->gf), len_2k, len_2k, this->pkt_size));

--- a/src/fec_rs_gf2n_fft.h
+++ b/src/fec_rs_gf2n_fft.h
@@ -76,9 +76,6 @@ class RsGf2nFft : public FecCode<T> {
         this->fft = std::unique_ptr<fft::CooleyTukey<T>>(
             new fft::CooleyTukey<T>(*(this->gf), this->n));
 
-        this->fft_full = std::unique_ptr<fft::CooleyTukey<T>>(
-            new fft::CooleyTukey<T>(*(this->gf), this->n));
-
         unsigned len_2k = this->gf->get_code_len_high_compo(2 * this->n_data);
         this->fft_2k = std::unique_ptr<fft::CooleyTukey<T>>(
             new fft::CooleyTukey<T>(*(this->gf), len_2k));

--- a/src/fec_rs_gfp_fft.h
+++ b/src/fec_rs_gfp_fft.h
@@ -120,12 +120,8 @@ class RsGfpFft : public FecCode<T> {
         if (arith::is_power_of_2<T>(this->n)) {
             this->fft = std::unique_ptr<fft::Radix2<T>>(
                 new fft::Radix2<T>(*(this->gf), this->n));
-            this->fft_full = std::unique_ptr<fft::Radix2<T>>(
-                new fft::Radix2<T>(*(this->gf), this->n));
         } else {
             this->fft = std::unique_ptr<fft::CooleyTukey<T>>(
-                new fft::CooleyTukey<T>(*(this->gf), this->n));
-            this->fft_full = std::unique_ptr<fft::CooleyTukey<T>>(
                 new fft::CooleyTukey<T>(*(this->gf), this->n));
         }
 

--- a/src/fec_rs_nf4.h
+++ b/src/fec_rs_nf4.h
@@ -91,9 +91,6 @@ class RsNf4 : public FecCode<T> {
         this->fft = std::unique_ptr<fft::Radix2<T>>(
             new fft::Radix2<T>(*ngff4, this->n, m, this->pkt_size));
 
-        this->fft_full = std::unique_ptr<fft::Radix2<T>>(
-            new fft::Radix2<T>(*ngff4, this->n, this->n, this->pkt_size));
-
         unsigned len_2k = this->gf->get_code_len_high_compo(2 * this->n_data);
         this->fft_2k = std::unique_ptr<fft::Radix2<T>>(
             new fft::Radix2<T>(*ngff4, len_2k, len_2k, this->pkt_size));
@@ -192,9 +189,6 @@ class RsNf4 : public FecCode<T> {
         }
         if (this->fft == nullptr) {
             throw LogicError("FEC base: FFT must be initialized");
-        }
-        if (this->fft_full == nullptr) {
-            throw LogicError("FEC base: FFT full must be initialized");
         }
 
         int k = this->n_data; // number of fragments received

--- a/src/fft_2n.h
+++ b/src/fft_2n.h
@@ -86,7 +86,7 @@ class Radix2 : public FourierTransform<T> {
     void fft_inv(vec::Buffers<T>& output, vec::Buffers<T>& input) override;
 
   private:
-    void _init_bitrev();
+    void init_bitrev();
 
     unsigned data_len; // number of real input elements
     T w;
@@ -125,11 +125,11 @@ Radix2<T>::Radix2(const gf::Field<T>& gf, int n, int data_len, size_t pkt_size)
     gf.compute_omegas(*inv_W, n, inv_w);
 
     rev = std::unique_ptr<T[]>(new T[n]);
-    _init_bitrev();
+    init_bitrev();
 }
 
 template <typename T>
-void Radix2<T>::_init_bitrev()
+void Radix2<T>::init_bitrev()
 {
     unsigned len = this->n;
     unsigned log_n = arith::log2<T>(len);

--- a/src/fft_2n.h
+++ b/src/fft_2n.h
@@ -31,6 +31,7 @@
 #ifndef __QUAD_FFT_2N_H__
 #define __QUAD_FFT_2N_H__
 
+#include "arith.h"
 #include "fft_2.h"
 #include "fft_base.h"
 #include "fft_single.h"
@@ -39,34 +40,34 @@
 #include "vec_vector.h"
 #include "vec_zero_ext.h"
 
+/** Compute bit-reversed number for a given number
+ *
+ * @param x - input number
+ * @param len - upper bound of the number's range. It is a power of 2
+ * @param bit_len - log2 of len
+ * @return - bit-reversed number of `x`
+ */
+inline unsigned reverse_bitwise(unsigned x, unsigned len, unsigned bit_len)
+{
+    unsigned mask = len;
+    unsigned res = 0;
+    unsigned bit_num = bit_len;
+    while (mask > 0) {
+        unsigned char bit = (x & mask) >> bit_num;
+        res |= (bit << (bit_len - 1 - bit_num)); // NOLINT
+        --bit_num;
+        mask >>= 1;
+    }
+    return res;
+}
+
 namespace quadiron {
 namespace fft {
 
-/** Implementation of the radix-2 decimation-in-time (DIT) FFT
+/** Implementation of the radix-2 FFT
  *
- * if \f$n = 2k\f$, then
- *
- * \f[
- *   F_{2k}(A) =
- *
- *   \begin{bmatrix}
- *     F_k(A_{\text{even}}) \\
- *     F_k(A_{\text{even}})
- *   \end{bmatrix}
- *
- *   +
- *
- *   \begin{bmatrix}
- *     1 & w & w^2 \dots w^{2k-1}
- *   \end{bmatrix}
- *
- *   \times
- *
- *   \begin{bmatrix}
- *     F_k(A_{\text{odd}}) \\
- *     F_k(A_{\text{odd}})
- *   \end{bmatrix}
- * \f]
+ * It uses bit-reversal permutation algorithm that is originally described in
+ * Algorithm 9.5.5 in \cite primenumbers
  */
 template <typename T>
 class Radix2 : public FourierTransform<T> {
@@ -74,9 +75,8 @@ class Radix2 : public FourierTransform<T> {
     Radix2(
         const gf::Field<T>& gf,
         int n,
-        int m = 0,
-        size_t pkt_size = 0,
-        int N = 0);
+        int data_len = 0,
+        size_t pkt_size = 0);
     ~Radix2() = default;
     void fft(vec::Vector<T>& output, vec::Vector<T>& input) override;
     void ifft(vec::Vector<T>& output, vec::Vector<T>& input) override;
@@ -86,32 +86,16 @@ class Radix2 : public FourierTransform<T> {
     void fft_inv(vec::Buffers<T>& output, vec::Buffers<T>& input) override;
 
   private:
-    void _fftp(vec::Buffers<T>& output, vec::Buffers<T>& input, bool inv);
-    void _fft(vec::Vector<T>& output, vec::Vector<T>& input, bool inv);
+    void _init_bitrev();
 
-    bool bypass;
-    int k;
-    int m; // number of real input elements
-    int N;
+    unsigned data_len; // number of real input elements
     T w;
     T inv_w;
     size_t pkt_size;
+
+    std::unique_ptr<T[]> rev = nullptr;
     std::unique_ptr<vec::Vector<T>> W = nullptr;
     std::unique_ptr<vec::Vector<T>> inv_W = nullptr;
-    std::unique_ptr<vec::Vector<T>> W_half = nullptr;
-    std::unique_ptr<vec::Vector<T>> inv_W_half = nullptr;
-
-    std::unique_ptr<fft::FourierTransform<T>> fft_trivial = nullptr;
-    std::unique_ptr<fft::Radix2<T>> fftk = nullptr;
-
-    std::unique_ptr<vec::Vector<T>> even = nullptr;
-    std::unique_ptr<vec::Vector<T>> _even = nullptr;
-    std::unique_ptr<vec::Vector<T>> odd = nullptr;
-    std::unique_ptr<vec::Vector<T>> _odd = nullptr;
-    std::unique_ptr<vec::Doubled<T>> veven = nullptr;
-    std::unique_ptr<vec::Doubled<T>> vodd = nullptr;
-
-    std::unique_ptr<vec::Buffers<T>> tmp_buf = nullptr;
 };
 
 /**
@@ -123,115 +107,133 @@ class Radix2 : public FourierTransform<T> {
  *  operation cycles
  * @param pkt_size size of packet, i.e. number of symbols per chunk will be
  *  received and processed at a time
- * @param N original length
  *
  * @return
  */
 template <typename T>
-Radix2<T>::Radix2(const gf::Field<T>& gf, int n, int m, size_t pkt_size, int N)
+Radix2<T>::Radix2(const gf::Field<T>& gf, int n, int data_len, size_t pkt_size)
     : FourierTransform<T>(gf, n)
 {
     w = gf.get_nth_root(n);
     inv_w = gf.inv(w);
     this->pkt_size = pkt_size;
-    this->N = N;
-    if (this->N == 0) {
-        this->N = n;
-    }
-    this->m = m > 0 ? m : n;
+    this->data_len = data_len > 0 ? data_len : n;
 
-    // Note: we need k to calculate ifft where k is checked == N/2
-    // It's necessary for FFT of length N = 2.
-    k = n / 2;
+    W = std::unique_ptr<vec::Vector<T>>(new vec::Vector<T>(gf, n));
+    inv_W = std::unique_ptr<vec::Vector<T>>(new vec::Vector<T>(gf, n));
+    gf.compute_omegas(*W, n, w);
+    gf.compute_omegas(*inv_W, n, inv_w);
 
-    if (this->m == 1) {
-        bypass = true;
-        this->fft_trivial =
-            std::unique_ptr<fft::Single<T>>(new fft::Single<T>(gf, this->n));
-    } else if (this->n <= 2) {
-        bypass = true;
-        this->fft_trivial =
-            std::unique_ptr<fft::Size2<T>>(new fft::Size2<T>(gf));
-    } else { // (this->m > 1 && this->n > 2)
-        bypass = false;
-
-        W = std::unique_ptr<vec::Vector<T>>(new vec::Vector<T>(gf, n));
-        inv_W = std::unique_ptr<vec::Vector<T>>(new vec::Vector<T>(gf, n));
-        gf.compute_omegas(*W, n, w);
-        gf.compute_omegas(*inv_W, n, inv_w);
-
-        W_half = std::unique_ptr<vec::Vector<T>>(new vec::Vector<T>(gf, k));
-        inv_W_half = std::unique_ptr<vec::Vector<T>>(new vec::Vector<T>(gf, k));
-        for (int i = 0; i < k; i++) {
-            W_half->set(i, W->get(i));
-            inv_W_half->set(i, inv_W->get(i));
-        }
-
-        int next_m = this->m / 2;
-        this->fftk = std::unique_ptr<Radix2<T>>(
-            new Radix2<T>(gf, k, next_m, pkt_size, this->N));
-
-        this->even = std::unique_ptr<vec::Vector<T>>(new vec::Vector<T>(gf, k));
-        this->_even =
-            std::unique_ptr<vec::Vector<T>>(new vec::Vector<T>(gf, k));
-        this->veven =
-            std::unique_ptr<vec::Doubled<T>>(new vec::Doubled<T>(*_even));
-        this->odd = std::unique_ptr<vec::Vector<T>>(new vec::Vector<T>(gf, k));
-        this->_odd = std::unique_ptr<vec::Vector<T>>(new vec::Vector<T>(gf, k));
-        this->vodd =
-            std::unique_ptr<vec::Doubled<T>>(new vec::Doubled<T>(*_odd));
-
-        // if (this->pkt_size > 0)
-        this->tmp_buf =
-            std::unique_ptr<vec::Buffers<T>>(new vec::Buffers<T>(k, pkt_size));
-    }
+    rev = std::unique_ptr<T[]>(new T[n]);
+    _init_bitrev();
 }
 
 template <typename T>
-void Radix2<T>::_fft(vec::Vector<T>& output, vec::Vector<T>& input, bool inv)
+void Radix2<T>::_init_bitrev()
 {
-    for (int i = 0; i < this->n; i++) {
-        if (i % 2 == 0)
-            even->set(i / 2, input.get(i));
-        else
-            odd->set(i / 2, input.get(i));
-    }
-    // this->even->dump();
-    // this->odd->dump();
-    if (inv) {
-        fftk->fft_inv(*_even, *even);
-        fftk->fft_inv(*_odd, *odd);
-    } else {
-        fftk->fft(*_even, *even);
-        fftk->fft(*_odd, *odd);
-    }
+    unsigned len = this->n;
+    unsigned log_n = arith::log2<T>(len);
 
-    if (inv)
-        output.copy(inv_W.get(), this->n);
-    else
-        output.copy(W.get(), this->n);
-    output.hadamard_mul(vodd.get());
-    output.add(veven.get());
+    // init bit-reversed indices
+    for (unsigned i = 0; i < len; ++i) {
+        rev[i] = reverse_bitwise(i, len, log_n);
+    }
 }
 
+/** Perform decimation-in-time FFT
+ *
+ * Process:
+ * - Output is initialized as the input in the bit-reversal ordering
+ * - Cooley-Tukey butterfly is performed on output
+ * It leads to a O(N*logN) complexity.
+ * @note: we consider particular cases where input is padded by zeros that
+ * always happens in erasure encoding process. Normally, FFT process starts
+ * performing butterfly operations on groups of size 2, then 4, 8 etc.
+ * Thanks to zero padding, we can start from a group size where there is at
+ * most a non-zero element of input in the group, all other elements of the
+ * group are zero. Indeed, after performing butterfly operation on the
+ * group, all elements equal to the non-zero one.
+ *
+ * Given FFT length N, number of data length K, output is initialized in
+ * the following clever way:
+ * - Each group contains N/K elements
+ * - Perform on groups containing non-zero element of input: copy input's
+ * element at the bit-reversed index to all elements of correspondent group
+ * of output
+ * - For other groups, initialize them normally
+ * It leads to a O(K*logN) complexity
+ *
+ * @param output - output vector
+ * @param input - input vector
+ */
 template <typename T>
 void Radix2<T>::fft(vec::Vector<T>& output, vec::Vector<T>& input)
 {
-    // input.dump();
+    unsigned len = this->n;
 
-    if (bypass)
-        return fft_trivial->fft(output, input);
-    else
-        return _fft(output, input, false);
+    unsigned group_len = len / data_len;
+    unsigned idx = 0;
+    for (unsigned group = 0; group < data_len; ++group) {
+        // set output  = scramble(input), i.e. bit reversal ordering
+        T a = input.get(rev[idx]);
+        output.set(idx, a);
+        unsigned end = idx + group_len;
+        for (unsigned i = idx + 1; i < end; ++i) {
+            output.set(i, a);
+        }
+        idx += group_len;
+    }
+    // set output  = scramble(input), i.e. bit reversal ordering
+    for (; idx < len; idx++) {
+        output.set(idx, input.get(rev[idx]));
+    }
+    // perform butterfly operations
+    for (unsigned m = group_len; m < len; m *= 2) {
+        unsigned doubled_m = 2 * m;
+        unsigned ratio = len / doubled_m;
+        for (unsigned j = 0; j < m; ++j) {
+            T r = W->get(j * ratio);
+            for (unsigned i = j; i < len; i += doubled_m) {
+                T a = output.get(i);
+                T b = this->gf->mul(r, output.get(i + m));
+                output.set(i, this->gf->add(a, b));
+                output.set(i + m, this->gf->sub(a, b));
+            }
+        }
+    }
 }
 
+/** Perform decimation-in-frequency FFT or inverse FFT
+ *
+ * Process:
+ * - Genteleman-Sande butterfly is performed on input
+ * - Output is copied from input at bit-reversed indices
+ * It leads to a O(N*logN) complexity.
+ *
+ * @param output - output vector
+ * @param input - input vector
+ */
 template <typename T>
 void Radix2<T>::fft_inv(vec::Vector<T>& output, vec::Vector<T>& input)
 {
-    if (bypass)
-        return fft_trivial->fft_inv(output, input);
-    else
-        return _fft(output, input, true);
+    unsigned len = this->n;
+    for (unsigned m = len / 2; m >= 1; m /= 2) {
+        unsigned doubled_m = 2 * m;
+        for (unsigned j = 0; j < m; ++j) {
+            T r = inv_W->get(j * len / doubled_m);
+            for (unsigned i = j; i < len; i += doubled_m) {
+                T a = input.get(i);
+                T b = input.get(i + m);
+                input.set(i, this->gf->add(a, b));
+                input.set(i + m, this->gf->mul(r, this->gf->sub(a, b)));
+            }
+        }
+    }
+
+    // set output  = scramble(input), i.e. bit reversal ordering
+    for (unsigned i = 0; i < len; i++) {
+        output.set(i, input.get(rev[i]));
+    }
 }
 
 template <typename T>
@@ -242,67 +244,81 @@ void Radix2<T>::ifft(vec::Vector<T>& output, vec::Vector<T>& input)
     /*
      * We need to divide output to `N` for the inverse formular
      */
-    if ((this->k == this->N / 2) && (this->inv_n_mod_p > 1))
-        output.mul_scalar(this->inv_n_mod_p);
+    output.mul_scalar(this->inv_n_mod_p);
 }
 
-template <typename T>
-void Radix2<T>::_fftp(vec::Buffers<T>& output, vec::Buffers<T>& input, bool inv)
-{
-    int half = this->n / 2;
-    size_t size = input.get_size();
-    std::vector<T*> even_mem(half, nullptr);
-    std::vector<T*> odd_mem(half, nullptr);
-    vec::Buffers<T> i_even(half, size, even_mem);
-    vec::Buffers<T> i_odd(half, size, odd_mem);
-
-    // separate even and odd elements of input
-    input.separate_even_odd(i_even, i_odd);
-
-    vec::Buffers<T> o_even(output, 0, half);
-    vec::Buffers<T> o_odd(output, half, this->n);
-
-    if (inv) {
-        fftk->fft_inv(o_even, i_even);
-        fftk->fft_inv(o_odd, i_odd);
-    } else {
-        fftk->fft(o_even, i_even);
-        fftk->fft(o_odd, i_odd);
-    }
-
-    /*
-     * output[i] = even[i] + w * odd[i] for 0 <= i < n/2
-     * output[i] = even[i] - w * odd[i] otherwise
-     */
-
-    // set tmp_buf = w * o_odd
-    if (inv)
-        this->gf->mul_vec_to_vecp(*inv_W_half, o_odd, *tmp_buf);
-    else
-        this->gf->mul_vec_to_vecp(*W_half, o_odd, *tmp_buf);
-
-    // substract o_even by tmp_buf and store in o_dd: o_even - w * o_odd
-    this->gf->sub_vecp_to_vecp(o_even, *tmp_buf, o_odd);
-    // add tmp_buf to o_even to get: o_even + w * o_odd
-    this->gf->add_vecp_to_vecp(*tmp_buf, o_even);
-}
-
+/** Perform decimation-in-time FFT
+ *
+ * @param output - output buffers
+ * @param input - input buffers
+ */
 template <typename T>
 void Radix2<T>::fft(vec::Buffers<T>& output, vec::Buffers<T>& input)
 {
-    if (bypass)
-        return fft_trivial->fft(output, input);
-    else
-        return _fftp(output, input, false);
+    unsigned len = this->n;
+    unsigned size = this->pkt_size;
+
+    unsigned group_len = len / data_len;
+    unsigned idx = 0;
+    for (unsigned group = 0; group < data_len; ++group) {
+        // set output  = scramble(input), i.e. bit reversal ordering
+        T* a = input.get(rev[idx]);
+        output.copy(idx, a);
+        unsigned end = idx + group_len;
+        for (unsigned i = idx + 1; i < end; ++i) {
+            output.copy(i, a);
+        }
+        idx += group_len;
+    }
+    // set output  = scramble(input), i.e. bit reversal ordering
+    for (; idx < len; ++idx) {
+        output.copy(idx, input.get(rev[idx]));
+    }
+    // perform butterfly operations
+    for (unsigned m = group_len; m < len; m *= 2) {
+        unsigned doubled_m = 2 * m;
+        for (unsigned j = 0; j < m; ++j) {
+            T r = W->get(j * len / doubled_m);
+            for (unsigned i = j; i < len; i += doubled_m) {
+                T* a = output.get(i);
+                T* b = output.get(i + m);
+
+                // perform butterfly operation for Cooley-Tukey FFT algorithm
+                this->gf->butterfly_ct(r, a, b, size);
+            }
+        }
+    }
 }
 
+/** Perform decimation-in-frequency FFT or inverse FFT
+ *
+ * @param output - output buffers
+ * @param input - input buffers
+ */
 template <typename T>
 void Radix2<T>::fft_inv(vec::Buffers<T>& output, vec::Buffers<T>& input)
 {
-    if (bypass)
-        return fft_trivial->fft_inv(output, input);
-    else
-        return _fftp(output, input, true);
+    unsigned size = this->pkt_size;
+
+    unsigned len = this->n;
+    for (unsigned m = len / 2; m >= 1; m /= 2) {
+        unsigned doubled_m = 2 * m;
+        for (unsigned j = 0; j < m; ++j) {
+            T r = inv_W->get(j * len / doubled_m);
+            for (unsigned i = j; i < len; i += doubled_m) {
+                T* a = input.get(i);
+                T* b = input.get(i + m);
+
+                // perform butterfly operation for Gentleman-Sande FFT algorithm
+                this->gf->butterfly_gs(r, a, b, size);
+            }
+        }
+    }
+
+    // set output  = scramble(input), i.e. bit reversal ordering
+    for (unsigned i = 0; i < len; i++) {
+        output.copy(i, input.get(rev[i]));
+    }
 }
 
 template <typename T>
@@ -313,8 +329,7 @@ void Radix2<T>::ifft(vec::Buffers<T>& output, vec::Buffers<T>& input)
     /*
      * We need to divide output to `N` for the inverse formular
      */
-    if ((this->k == this->N / 2) && (this->inv_n_mod_p > 1))
-        this->gf->mul_vec_to_vecp(*(this->vec_inv_n), output, output);
+    this->gf->mul_vec_to_vecp(*(this->vec_inv_n), output, output);
 }
 
 } // namespace fft

--- a/src/fft_add.h
+++ b/src/fft_add.h
@@ -101,7 +101,7 @@ class Additive : public FourierTransform<T> {
  */
 template <typename T>
 Additive<T>::Additive(const gf::Field<T>& gf, T m, vec::Vector<T>* betas)
-    : FourierTransform<T>(gf, arith::exp2<T>(m))
+    : FourierTransform<T>(gf, arith::exp2<T>(m), true)
 {
     assert(m >= 1);
     this->m = m;

--- a/src/fft_base.h
+++ b/src/fft_base.h
@@ -66,19 +66,25 @@ class FourierTransform {
     int n;
     T inv_n_mod_p;
     vec::Vector<T>* vec_inv_n = nullptr;
-    FourierTransform(const gf::Field<T>& gf, int n);
+    FourierTransform(const gf::Field<T>& gf, int n, bool additive = false);
 };
 
 template <typename T>
-FourierTransform<T>::FourierTransform(const gf::Field<T>& gf, int n)
+FourierTransform<T>::FourierTransform(
+    const gf::Field<T>& gf,
+    int n,
+    bool additive)
 {
     this->gf = &gf;
     this->n = n;
-    this->inv_n_mod_p = gf.get_inv_n_mod_p(n);
 
-    this->vec_inv_n = new vec::Vector<T>(gf, n);
-    for (int i = 0; i < n; i++) {
-        this->vec_inv_n->set(i, this->inv_n_mod_p);
+    if (!additive) {
+        this->inv_n_mod_p = gf.get_inv_n_mod_p(n);
+
+        this->vec_inv_n = new vec::Vector<T>(gf, n);
+        for (int i = 0; i < n; i++) {
+            this->vec_inv_n->set(i, this->inv_n_mod_p);
+        }
     }
 }
 

--- a/src/gf_ring.cpp
+++ b/src/gf_ring.cpp
@@ -59,6 +59,108 @@ void RingModN<uint32_t>::mul_coef_to_buf(
 }
 
 template <>
+void RingModN<uint16_t>::butterfly_ct(
+    uint16_t coef,
+    uint16_t* buf1,
+    uint16_t* buf2,
+    size_t len) const
+{
+    unsigned ratio = ALIGN_SIZE / sizeof(*buf1);
+    size_t vec_len = len / ratio;
+    size_t last_len = len - vec_len * ratio;
+
+    // perform vector operations
+    simd::butterfly_ct(coef, buf1, buf2, vec_len, this->_card);
+
+    // for last elements, perform as non-SIMD method
+    if (last_len > 0) {
+        for (size_t i = vec_len * ratio; i < len; ++i) {
+            uint16_t a = buf1[i];
+            uint16_t b = mul(coef, buf2[i]);
+            buf1[i] = add(a, b);
+            buf2[i] = sub(a, b);
+        }
+    }
+}
+
+template <>
+void RingModN<uint32_t>::butterfly_ct(
+    uint32_t coef,
+    uint32_t* buf1,
+    uint32_t* buf2,
+    size_t len) const
+{
+    unsigned ratio = ALIGN_SIZE / sizeof(*buf1);
+    size_t vec_len = len / ratio;
+    size_t last_len = len - vec_len * ratio;
+
+    // perform vector operations
+    simd::butterfly_ct(coef, buf1, buf2, vec_len, this->_card);
+
+    // for last elements, perform as non-SIMD method
+    if (last_len > 0) {
+        for (size_t i = vec_len * ratio; i < len; ++i) {
+            uint32_t a = buf1[i];
+            uint32_t b = mul(coef, buf2[i]);
+            buf1[i] = add(a, b);
+            buf2[i] = sub(a, b);
+        }
+    }
+}
+
+template <>
+void RingModN<uint16_t>::butterfly_gs(
+    uint16_t coef,
+    uint16_t* buf1,
+    uint16_t* buf2,
+    size_t len) const
+{
+    unsigned ratio = ALIGN_SIZE / sizeof(*buf1);
+    size_t vec_len = len / ratio;
+    size_t last_len = len - vec_len * ratio;
+
+    // perform vector operations
+    simd::butterfly_gs(coef, buf1, buf2, vec_len, this->_card);
+
+    // for last elements, perform as non-SIMD method
+    if (last_len > 0) {
+        for (size_t i = vec_len * ratio; i < len; ++i) {
+            uint16_t a = buf1[i];
+            uint16_t b = buf2[i];
+            uint16_t c = sub(a, b);
+            buf1[i] = add(a, b);
+            buf2[i] = mul(coef, c);
+        }
+    }
+}
+
+template <>
+void RingModN<uint32_t>::butterfly_gs(
+    uint32_t coef,
+    uint32_t* buf1,
+    uint32_t* buf2,
+    size_t len) const
+{
+    unsigned ratio = ALIGN_SIZE / sizeof(*buf1);
+    size_t vec_len = len / ratio;
+    size_t last_len = len - vec_len * ratio;
+
+    // perform vector operations
+    simd::butterfly_gs(coef, buf1, buf2, vec_len, this->_card);
+
+    // for last elements, perform as non-SIMD method
+    if (last_len > 0) {
+        for (size_t i = vec_len * ratio; i < len; ++i) {
+            uint32_t a = buf1[i];
+            uint32_t b = buf2[i];
+            uint32_t c = sub(a, b);
+            buf1[i] = add(a, b);
+            buf2[i] = mul(coef, c);
+        }
+    }
+}
+
+template <>
 void RingModN<uint32_t>::add_two_bufs(uint32_t* src, uint32_t* dest, size_t len)
     const
 {

--- a/src/gf_ring.h
+++ b/src/gf_ring.h
@@ -108,6 +108,8 @@ class RingModN {
         vec::Buffers<T>& veca,
         vec::Buffers<T>& vecb,
         vec::Buffers<T>& res) const;
+    virtual void butterfly_ct(T coef, T* buf1, T* buf2, size_t len) const;
+    virtual void butterfly_gs(T coef, T* buf1, T* buf2, size_t len) const;
     bool is_quadratic_residue(T q) const;
     virtual void compute_omegas(vec::Vector<T>& W, int n, T w) const;
     void compute_omegas_cached(vec::Vector<T>& W, int n, T w) const;
@@ -457,6 +459,61 @@ inline void RingModN<T>::sub_vecp_to_vecp(
     size_t len = veca.get_size();
     for (i = 0; i < n; i++) {
         this->sub_two_bufs(veca.get(i), vecb.get(i), res.get(i), len);
+    }
+}
+
+/** Butterfly computation for Cooley-Tukey FFT algorithm
+ *
+ * Perform in-place oprations on two buffers `P`, `Q` with a coefficient `c`
+ * \f{eqnarray*}{
+ *  P_i &= P_i + c \times Q_i \\
+ *  Q_i &= P_i - c \times Q_i \\
+ * \f}
+ *
+ * @param coef - coefficient, a finite field element
+ * @param buf1 - a buffer of `len` elements
+ * @param buf2 - a buffer of `len` elements
+ * @param len - number of elements per buffer
+ * @return
+ */
+template <typename T>
+inline void
+RingModN<T>::butterfly_ct(T coef, T* buf1, T* buf2, size_t len) const
+{
+    size_t i;
+    for (i = 0; i < len; ++i) {
+        T a = buf1[i];
+        T b = mul(coef, buf2[i]);
+        buf1[i] = add(a, b);
+        buf2[i] = sub(a, b);
+    }
+}
+
+/** Butterfly computation for Gentleman-Sande FFT algorithm
+ *
+ * Perform in-place oprations on two buffers `P`, `Q` with a coefficient `c`
+ * \f{eqnarray*}{
+ *  P_i &= P_i + Q_i \\
+ *  Q_i &= c \times (P_i - Q_i)
+ * \f}
+ *
+ * @param coef - coefficient, a finite field element
+ * @param buf1 - a buffer of `len` elements
+ * @param buf2 - a buffer of `len` elements
+ * @param len - number of elements per buffer
+ * @return
+ */
+template <typename T>
+inline void
+RingModN<T>::butterfly_gs(T coef, T* buf1, T* buf2, size_t len) const
+{
+    size_t i;
+    for (i = 0; i < len; ++i) {
+        T a = buf1[i];
+        T b = buf2[i];
+        T c = sub(a, b);
+        buf1[i] = add(a, b);
+        buf2[i] = mul(coef, c);
     }
 }
 

--- a/src/gf_ring.h
+++ b/src/gf_ring.h
@@ -465,6 +465,7 @@ inline void RingModN<T>::sub_vecp_to_vecp(
 /** Butterfly computation for Cooley-Tukey FFT algorithm
  *
  * Perform in-place oprations on two buffers `P`, `Q` with a coefficient `c`
+ *
  * \f{eqnarray*}{
  *  P_i &= P_i + c \times Q_i \\
  *  Q_i &= P_i - c \times Q_i \\
@@ -474,7 +475,6 @@ inline void RingModN<T>::sub_vecp_to_vecp(
  * @param buf1 - a buffer of `len` elements
  * @param buf2 - a buffer of `len` elements
  * @param len - number of elements per buffer
- * @return
  */
 template <typename T>
 inline void
@@ -492,6 +492,7 @@ RingModN<T>::butterfly_ct(T coef, T* buf1, T* buf2, size_t len) const
 /** Butterfly computation for Gentleman-Sande FFT algorithm
  *
  * Perform in-place oprations on two buffers `P`, `Q` with a coefficient `c`
+ *
  * \f{eqnarray*}{
  *  P_i &= P_i + Q_i \\
  *  Q_i &= c \times (P_i - Q_i)
@@ -501,7 +502,6 @@ RingModN<T>::butterfly_ct(T coef, T* buf1, T* buf2, size_t len) const
  * @param buf1 - a buffer of `len` elements
  * @param buf2 - a buffer of `len` elements
  * @param len - number of elements per buffer
- * @return
  */
 template <typename T>
 inline void

--- a/src/gf_ring.h
+++ b/src/gf_ring.h
@@ -1004,6 +1004,34 @@ void RingModN<uint32_t>::sub_two_bufs(
     size_t len) const;
 
 template <>
+void RingModN<uint16_t>::butterfly_ct(
+    uint16_t coef,
+    uint16_t* buf1,
+    uint16_t* buf2,
+    size_t len) const;
+
+template <>
+void RingModN<uint32_t>::butterfly_ct(
+    uint32_t coef,
+    uint32_t* buf1,
+    uint32_t* buf2,
+    size_t len) const;
+
+template <>
+void RingModN<uint16_t>::butterfly_gs(
+    uint16_t coef,
+    uint16_t* buf1,
+    uint16_t* buf2,
+    size_t len) const;
+
+template <>
+void RingModN<uint32_t>::butterfly_gs(
+    uint32_t coef,
+    uint32_t* buf1,
+    uint32_t* buf2,
+    size_t len) const;
+
+template <>
 void RingModN<uint16_t>::hadamard_mul(int n, uint16_t* x, uint16_t* y) const;
 template <>
 void RingModN<uint32_t>::hadamard_mul(int n, uint32_t* x, uint32_t* y) const;

--- a/src/simd_128_u16.h
+++ b/src/simd_128_u16.h
@@ -268,6 +268,52 @@ mul_two_bufs(aint16* src, aint16* dest, size_t len, aint16 card = F3)
     }
 }
 
+/*
+ * buf1[i] = buf1[i] + coef * buf2[i]
+ * buf2[i] = buf1[i] - coef * buf2[i]
+ */
+inline void butterfly_ct(
+    uint16_t coef,
+    aint16* buf1,
+    aint16* buf2,
+    size_t len,
+    uint32_t card = F3)
+{
+    const m128i _coef = _mm_set1_epi16(coef);
+    m128i* _buf1 = reinterpret_cast<m128i*>(buf1);
+    m128i* _buf2 = reinterpret_cast<m128i*>(buf2);
+
+    for (size_t i = 0; i < len; ++i) {
+        m128i a = mul(_coef, _buf2[i], card);
+        _buf2[i] = sub(_buf1[i], a, card);
+        _buf1[i] = add(_buf1[i], a, card);
+    }
+}
+
+/*
+ * buf1[i] = buf1[i] + buf2[i]
+ * buf2[i] = coef * (buf1[i] - buf2[i])
+ */
+inline void butterfly_gs(
+    uint16_t coef,
+    aint16* buf1,
+    aint16* buf2,
+    size_t len,
+    uint16_t card = F3)
+{
+    const m128i _coef = _mm_set1_epi16(coef);
+    m128i* _buf1 = reinterpret_cast<m128i*>(buf1);
+    m128i* _buf2 = reinterpret_cast<m128i*>(buf2);
+
+    for (size_t i = 0; i < len; ++i) {
+        m128i a = _buf1[i];
+        m128i b = _buf2[i];
+        m128i c = sub(a, b, card);
+        _buf1[i] = add(a, b, card);
+        _buf2[i] = mul(_coef, c, card);
+    }
+}
+
 } // namespace simd
 } // namespace quadiron
 

--- a/src/simd_128_u32.h
+++ b/src/simd_128_u32.h
@@ -312,6 +312,52 @@ mul_two_bufs(aint32* src, aint32* dest, size_t len, aint32 card = F4)
     }
 }
 
+/*
+ * buf1[i] = buf1[i] + coef * buf2[i]
+ * buf2[i] = buf1[i] - coef * buf2[i]
+ */
+inline void butterfly_ct(
+    uint32_t coef,
+    aint32* buf1,
+    aint32* buf2,
+    size_t len,
+    uint32_t card = F4)
+{
+    const m128i _coef = _mm_set1_epi32(coef);
+    m128i* _buf1 = reinterpret_cast<m128i*>(buf1);
+    m128i* _buf2 = reinterpret_cast<m128i*>(buf2);
+
+    for (size_t i = 0; i < len; ++i) {
+        m128i a = mul(_coef, _buf2[i], card);
+        _buf2[i] = sub(_buf1[i], a, card);
+        _buf1[i] = add(_buf1[i], a, card);
+    }
+}
+
+/*
+ * buf1[i] = buf1[i] + buf2[i]
+ * buf2[i] = coef * (buf1[i] - buf2[i])
+ */
+inline void butterfly_gs(
+    uint32_t coef,
+    aint32* buf1,
+    aint32* buf2,
+    size_t len,
+    uint32_t card = F4)
+{
+    const m128i _coef = _mm_set1_epi32(coef);
+    m128i* _buf1 = reinterpret_cast<m128i*>(buf1);
+    m128i* _buf2 = reinterpret_cast<m128i*>(buf2);
+
+    for (size_t i = 0; i < len; ++i) {
+        m128i a = _buf1[i];
+        m128i b = _buf2[i];
+        m128i c = sub(a, b, card);
+        _buf1[i] = add(a, b, card);
+        _buf2[i] = mul(_coef, c, card);
+    }
+}
+
 /* ==================== Operations for NF4 =================== */
 
 /** Return aint128 integer from a _m128i register */

--- a/src/simd_256_u16.h
+++ b/src/simd_256_u16.h
@@ -265,6 +265,52 @@ mul_two_bufs(aint16* src, aint16* dest, size_t len, aint16 card = F3)
     }
 }
 
+/*
+ * buf1[i] = buf1[i] + coef * buf2[i]
+ * buf2[i] = buf1[i] - coef * buf2[i]
+ */
+inline void butterfly_ct(
+    uint16_t coef,
+    aint16* buf1,
+    aint16* buf2,
+    size_t len,
+    uint16_t card = F3)
+{
+    const m256i _coef = _mm256_set1_epi16(coef);
+    m256i* _buf1 = reinterpret_cast<m256i*>(buf1);
+    m256i* _buf2 = reinterpret_cast<m256i*>(buf2);
+
+    for (size_t i = 0; i < len; ++i) {
+        m256i a = mul(_coef, _buf2[i], card);
+        _buf2[i] = sub(_buf1[i], a, card);
+        _buf1[i] = add(_buf1[i], a, card);
+    }
+}
+
+/*
+ * buf1[i] = buf1[i] + buf2[i]
+ * buf2[i] = coef * (buf1[i] - buf2[i])
+ */
+inline void butterfly_gs(
+    uint16_t coef,
+    aint16* buf1,
+    aint16* buf2,
+    size_t len,
+    uint16_t card = F3)
+{
+    const m256i _coef = _mm256_set1_epi16(coef);
+    m256i* _buf1 = reinterpret_cast<m256i*>(buf1);
+    m256i* _buf2 = reinterpret_cast<m256i*>(buf2);
+
+    for (size_t i = 0; i < len; ++i) {
+        m256i a = _buf1[i];
+        m256i b = _buf2[i];
+        m256i c = sub(a, b, card);
+        _buf1[i] = add(a, b, card);
+        _buf2[i] = mul(_coef, c, card);
+    }
+}
+
 } // namespace simd
 } // namespace quadiron
 


### PR DESCRIPTION
Implement FFT Radix2 using bit-reversal permutation algorithm.

1. Decimation-in-time FFT
- Output is initialized as the input in the bit-reversal ordering
- Cooley-Tukey butterfly is performed on the output

It leads to an O(N*logN) complexity.

Note, we consider particular cases where the input is padded by zeros that always happens in erasure encoding process. Normally, FFT process starts performing butterfly operations on groups of size 2, then 4, 8 etc. Thanks to zero padding, we can start from a group size where there is at most a non-zero element of input in the group, all other elements of the group are zero. Indeed, after performing butterfly operation on the group, all elements equal to the non-zero one.

Given FFT length N, number of data length K, the output is initialized in the following clever way:
- Each group contains N/K elements
- Perform on groups containing a non-zero element of input: copy input's element at the bit-reversed index to all elements of the correspondent group of output
- For other groups, initialize them normally

It leads to an O(N*logK) complexity

2. Decimation-in-frequency FFT or inverse FFT
- Gentleman-Sande butterfly is performed on the input
- Output is copied from input at bit-reversed indices

It leads to an O(N*logN) complexity.