### PR TITLE
FEC FNT: enhance encoding

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ include(GNUInstallDirs)
 # Source files.
 set(LIB_SRC
   ${SOURCE_DIR}/core.cpp
+  ${SOURCE_DIR}/fec_vectorisation.cpp
   ${SOURCE_DIR}/misc.cpp
   ${SOURCE_DIR}/gf_nf4.cpp
   ${SOURCE_DIR}/gf_ring.cpp

--- a/src/fec_base.h
+++ b/src/fec_base.h
@@ -49,6 +49,12 @@
 #include "vec_slice.h"
 #include "vec_vector.h"
 
+#ifdef QUADIRON_USE_SIMD
+
+#include "simd.h"
+
+#endif // #ifdef QUADIRON_USE_SIMD
+
 namespace quadiron {
 
 /** Forward Error Correction code implementations. */

--- a/src/fec_base.h
+++ b/src/fec_base.h
@@ -418,6 +418,11 @@ void FecCode<T>::encode_bufs(
     vec::Vector<T> words(*(this->gf), n_data);
     vec::Vector<T> output(*(this->gf), get_n_outputs());
 
+    // clear property vectors
+    for (unsigned i = 0; i < n_outputs; i++) {
+        output_parities_props[i].clear();
+    }
+
     reset_stats_enc();
 
     while (true) {
@@ -464,6 +469,11 @@ void FecCode<T>::encode_packet(
     assert(input_data_bufs.size() == n_data);
     assert(output_parities_bufs.size() == n_outputs);
     assert(output_parities_props.size() == n_outputs);
+
+    // clear property vectors
+    for (unsigned i = 0; i < n_outputs; i++) {
+        output_parities_props[i].clear();
+    }
 
     bool cont = true;
     off_t offset = 0;

--- a/src/fec_base.h
+++ b/src/fec_base.h
@@ -419,8 +419,8 @@ void FecCode<T>::encode_bufs(
     vec::Vector<T> output(*(this->gf), get_n_outputs());
 
     // clear property vectors
-    for (unsigned i = 0; i < n_outputs; i++) {
-        output_parities_props[i].clear();
+    for (auto& props : output_parities_props) {
+        props.clear();
     }
 
     reset_stats_enc();
@@ -471,8 +471,8 @@ void FecCode<T>::encode_packet(
     assert(output_parities_props.size() == n_outputs);
 
     // clear property vectors
-    for (unsigned i = 0; i < n_outputs; i++) {
-        output_parities_props[i].clear();
+    for (auto& props : output_parities_props) {
+        props.clear();
     }
 
     bool cont = true;

--- a/src/fec_base.h
+++ b/src/fec_base.h
@@ -128,11 +128,19 @@ class FecCode {
         std::vector<Properties>& props,
         off_t offset,
         vec::Vector<T>& words) = 0;
+    virtual void encode_post_process(
+        vec::Vector<T>& output,
+        std::vector<Properties>& props,
+        off_t offset){};
     virtual void encode(
         vec::Buffers<T>& output,
         std::vector<Properties>& props,
         off_t offset,
         vec::Buffers<T>& words){};
+    virtual void encode_post_process(
+        vec::Buffers<T>& output,
+        std::vector<Properties>& props,
+        off_t offset){};
     virtual void decode_add_data(int fragment_index, int row) = 0;
     virtual void decode_add_parities(int fragment_index, int row) = 0;
     virtual void decode_build(void) = 0;

--- a/src/fec_base.h
+++ b/src/fec_base.h
@@ -456,7 +456,7 @@ void FecCode<T>::encode_bufs(
             T tmp = output.get(i);
             writew(tmp, output_parities_bufs[i]);
         }
-        offset += word_size;
+        offset++;
     }
 }
 
@@ -528,7 +528,7 @@ void FecCode<T>::encode_packet(
             write_pkt(
                 (char*)(output_mem_char.at(i)), *(output_parities_bufs[i]));
         }
-        offset += buf_size;
+        offset += pkt_size;
     }
 }
 
@@ -665,7 +665,7 @@ bool FecCode<T>::decode_bufs(
             }
         }
 
-        offset += word_size;
+        offset++;
     }
 
     return true;
@@ -1008,7 +1008,7 @@ bool FecCode<T>::decode_packet(
                     (char*)(output_mem_char.at(i)), *(output_data_bufs[i]));
             }
         }
-        offset += buf_size;
+        offset += pkt_size;
     }
 
     return true;
@@ -1054,7 +1054,7 @@ void FecCode<T>::decode_prepare(
     // FIXME: could we integrate this preparation into vec::pack?
     // It will reduce a loop on all data
     const vec::Vector<T>& fragments_ids = context.get_fragments_id();
-    off_t offset_max = offset + buf_size;
+    off_t offset_max = offset + pkt_size;
 
     T thres = (this->gf->card() - 1);
     for (unsigned i = 0; i < this->n_data; i++) {
@@ -1064,8 +1064,8 @@ void FecCode<T>::decode_prepare(
         for (auto const& data : props[frag_id].get_map()) {
             off_t loc_offset = data.first.get_offset();
             if (loc_offset >= offset && loc_offset < offset_max) {
-                // As loc.offset := offset + j * this->word_size
-                const size_t j = (loc_offset - offset) / this->word_size;
+                // As loc.offset := offset + j
+                const size_t j = (loc_offset - offset);
 
                 // Check if the symbol is a special case whick is marked by "@".
                 // Note: this check is necessary when word_size is not large

--- a/src/fec_rs_fnt.h
+++ b/src/fec_rs_fnt.h
@@ -141,6 +141,14 @@ class RsFnt : public FecCode<T> {
         vec::Vector<T>& words) override
     {
         this->fft->fft(output, words);
+        encode_post_process(output, props, offset);
+    }
+
+    void encode_post_process(
+        vec::Vector<T>& output,
+        std::vector<Properties>& props,
+        off_t offset) override
+    {
         // max_value = 2^x
         T thres = this->gf->card() - 1;
         // check for out of range value in output
@@ -159,17 +167,24 @@ class RsFnt : public FecCode<T> {
         vec::Buffers<T>& words) override
     {
         this->fft->fft(output, words);
+        encode_post_process(output, props, offset);
+    }
+
+    void encode_post_process(
+        vec::Buffers<T>& output,
+        std::vector<Properties>& props,
+        off_t offset) override
+    {
         // check for out of range value in output
-        int size = output.get_size();
+        unsigned size = output.get_size();
         T thres = (this->gf->card() - 1);
-        for (unsigned i = 0; i < this->code_len; i++) {
+        for (unsigned i = 0; i < this->code_len; ++i) {
             T* chunk = output.get(i);
-            for (int j = 0; j < size; j++) {
+            for (unsigned j = 0; j < size; ++j) {
                 if (chunk[j] & thres) {
-                    const ValueLocation loc(offset + j * this->word_size, i);
+                    const ValueLocation loc(offset + j, i);
 
                     props[i].add(loc, "@");
-                    chunk[j] = 0;
                 }
             }
         }

--- a/src/fec_rs_fnt.h
+++ b/src/fec_rs_fnt.h
@@ -207,6 +207,24 @@ class RsFnt : public FecCode<T> {
     }
 };
 
+#ifdef QUADIRON_USE_SIMD
+
+/* Operations are vectorized by SIMD */
+
+template <>
+void RsFnt<uint16_t>::encode_post_process(
+    vec::Buffers<uint16_t>& output,
+    std::vector<Properties>& props,
+    off_t offset);
+
+template <>
+void RsFnt<uint32_t>::encode_post_process(
+    vec::Buffers<uint32_t>& output,
+    std::vector<Properties>& props,
+    off_t offset);
+
+#endif // #ifdef QUADIRON_USE_SIMD
+
 } // namespace fec
 } // namespace quadiron
 

--- a/src/fec_rs_gfp_fft.h
+++ b/src/fec_rs_gfp_fft.h
@@ -173,6 +173,14 @@ class RsGfpFft : public FecCode<T> {
     {
         vec::ZeroExtended<T> vwords(words, this->n);
         this->fft->fft(output, vwords);
+        encode_post_process(output, props, offset);
+    }
+
+    void encode_post_process(
+        vec::Vector<T>& output,
+        std::vector<Properties>& props,
+        off_t offset) override
+    {
         // check for out of range value in output
         for (unsigned i = 0; i < this->code_len; i++) {
             if (output.get(i) >= this->limit_value) {

--- a/src/fec_rs_nf4.h
+++ b/src/fec_rs_nf4.h
@@ -275,8 +275,7 @@ class RsNf4 : public FecCode<T> {
             for (size_t symb_id = 0; symb_id < size; symb_id++) {
                 ngff4->unpack(chunk[symb_id], true_val);
                 if (true_val.flag > 0) {
-                    const ValueLocation loc(
-                        offset + symb_id * this->word_size, frag_id);
+                    const ValueLocation loc(offset + symb_id, frag_id);
                     props[frag_id].add(loc, std::to_string(true_val.flag));
                 }
                 chunk[symb_id] = true_val.values;
@@ -291,7 +290,7 @@ class RsNf4 : public FecCode<T> {
         vec::Buffers<T>& words) override
     {
         const vec::Vector<T>& fragments_ids = context.get_fragments_id();
-        off_t offset_max = offset + this->buf_size;
+        off_t offset_max = offset + this->pkt_size;
         for (unsigned i = 0; i < this->n_data; ++i) {
             const int frag_id = fragments_ids.get(i);
             T* chunk = words.get(i);
@@ -304,8 +303,8 @@ class RsNf4 : public FecCode<T> {
             for (auto const& data : props[frag_id].get_map()) {
                 const off_t loc_offset = data.first.get_offset();
                 if (loc_offset >= offset && loc_offset < offset_max) {
-                    // As loc.offset := offset + j * this->word_size
-                    const size_t j = (loc_offset - offset) / this->word_size;
+                    // As loc.offset := offset + j
+                    const size_t j = loc_offset - offset;
                     packed_symbs.push_back(j);
                     // pack symbol at index `j`
                     uint32_t flag = std::stoul(data.second);

--- a/src/fec_rs_nf4.h
+++ b/src/fec_rs_nf4.h
@@ -139,6 +139,14 @@ class RsNf4 : public FecCode<T> {
         // std::cout << "pack words:"; words.dump();
         vec::ZeroExtended<T> vwords(words, this->n);
         this->fft->fft(output, vwords);
+        encode_post_process(output, props, offset);
+    }
+
+    void encode_post_process(
+        vec::Vector<T>& output,
+        std::vector<Properties>& props,
+        off_t offset) override
+    {
         // std::cout << "encoded:"; output.dump();
         GroupedValues<T> true_val;
         for (unsigned i = 0; i < this->code_len; i++) {
@@ -268,6 +276,14 @@ class RsNf4 : public FecCode<T> {
         }
         vec::BuffersZeroExtended<T> vwords(words, this->n);
         this->fft->fft(output, vwords);
+        encode_post_process(output, props, offset);
+    }
+
+    void encode_post_process(
+        vec::Buffers<T>& output,
+        std::vector<Properties>& props,
+        off_t offset) override
+    {
         size_t size = output.get_size();
         GroupedValues<T> true_val;
         for (unsigned frag_id = 0; frag_id < this->code_len; ++frag_id) {

--- a/src/fec_vectorisation.cpp
+++ b/src/fec_vectorisation.cpp
@@ -1,0 +1,114 @@
+/* -*- mode: c++ -*- */
+/*
+ * Copyright 2017-2018 Scality
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fec_rs_fnt.h"
+
+/*
+ * The file includes vectorized operations used by FEC classes
+ */
+
+#ifdef QUADIRON_USE_SIMD
+
+#include "simd.h"
+
+namespace quadiron {
+namespace fec {
+
+template <>
+void RsFnt<uint16_t>::encode_post_process(
+    vec::Buffers<uint16_t>& output,
+    std::vector<Properties>& props,
+    off_t offset)
+{
+    size_t size = this->pkt_size;
+    uint16_t threshold = this->gf->card_minus_one();
+    unsigned code_len = this->code_len;
+
+    // number of elements per vector register
+    unsigned vec_size = ALIGN_SIZE / sizeof(uint16_t);
+    // number of vector registers per fragment packet
+    size_t vecs_nb = size / vec_size;
+    // odd number of elements not vectorized
+    size_t last_len = size - vecs_nb * vec_size;
+
+    simd::encode_post_process(
+        output, props, offset, code_len, threshold, vecs_nb);
+
+    if (last_len > 0) {
+        for (unsigned i = 0; i < code_len; ++i) {
+            uint16_t* chunk = output.get(i);
+            for (size_t j = vecs_nb * vec_size; j < size; ++j) {
+                if (chunk[j] == threshold) {
+                    const ValueLocation loc(offset + j, i);
+                    props[i].add(loc, "@");
+                }
+            }
+        }
+    }
+}
+
+template <>
+void RsFnt<uint32_t>::encode_post_process(
+    vec::Buffers<uint32_t>& output,
+    std::vector<Properties>& props,
+    off_t offset)
+{
+    size_t size = this->pkt_size;
+    uint32_t threshold = this->gf->card_minus_one();
+    unsigned code_len = this->code_len;
+
+    // number of elements per vector register
+    unsigned vec_size = ALIGN_SIZE / sizeof(uint32_t);
+    // number of vector registers per fragment packet
+    size_t vecs_nb = size / vec_size;
+    // odd number of elements not vectorized
+    size_t last_len = size - vecs_nb * vec_size;
+
+    simd::encode_post_process(
+        output, props, offset, code_len, threshold, vecs_nb);
+
+    if (last_len > 0) {
+        for (unsigned i = 0; i < code_len; ++i) {
+            uint32_t* chunk = output.get(i);
+            for (size_t j = vecs_nb * vec_size; j < size; ++j) {
+                if (chunk[j] == threshold) {
+                    const ValueLocation loc(offset + j, i);
+                    props[i].add(loc, "@");
+                }
+            }
+        }
+    }
+}
+
+} // namespace fec
+} // namespace quadiron
+
+#endif // #ifdef QUADIRON_USE_SIMD

--- a/src/fec_vectorisation.cpp
+++ b/src/fec_vectorisation.cpp
@@ -81,16 +81,16 @@ void RsFnt<uint32_t>::encode_post_process(
     std::vector<Properties>& props,
     off_t offset)
 {
-    size_t size = this->pkt_size;
-    uint32_t threshold = this->gf->card_minus_one();
-    unsigned code_len = this->code_len;
+    const size_t size = this->pkt_size;
+    const uint32_t threshold = this->gf->card_minus_one();
+    const unsigned code_len = this->code_len;
 
     // number of elements per vector register
-    unsigned vec_size = ALIGN_SIZE / sizeof(uint32_t);
+    const unsigned vec_size = ALIGN_SIZE / sizeof(uint32_t);
     // number of vector registers per fragment packet
-    size_t vecs_nb = size / vec_size;
+    const size_t vecs_nb = size / vec_size;
     // odd number of elements not vectorized
-    size_t last_len = size - vecs_nb * vec_size;
+    const size_t last_len = size - vecs_nb * vec_size;
 
     simd::encode_post_process(
         output, props, offset, code_len, threshold, vecs_nb);

--- a/src/simd.h
+++ b/src/simd.h
@@ -33,8 +33,6 @@
 
 #ifdef QUADIRON_USE_SIMD
 
-#include "property.h"
-
 const unsigned F4 = 65537;
 const unsigned F3 = 257;
 

--- a/src/simd.h
+++ b/src/simd.h
@@ -33,6 +33,8 @@
 
 #ifdef QUADIRON_USE_SIMD
 
+#include "property.h"
+
 const unsigned F4 = 65537;
 const unsigned F3 = 257;
 

--- a/src/simd_128_u16.h
+++ b/src/simd_128_u16.h
@@ -335,9 +335,9 @@ inline void encode_post_process(
         uint16_t* chunk = output.get(frag_id);
         m128i* buf = reinterpret_cast<m128i*>(chunk);
         for (unsigned vec_id = 0; vec_id < vecs_nb; ++vec_id) {
-            m128i a = _mm_load_si128(&(buf[vec_id]));
-            m128i b = _mm_cmpeq_epi16(_threshold, a);
-            m128i c = _mm_and_si128(mask_hi, b);
+            const m128i a = _mm_load_si128(&(buf[vec_id]));
+            const m128i b = _mm_cmpeq_epi16(_threshold, a);
+            const m128i c = _mm_and_si128(mask_hi, b);
             uint16_t d = _mm_movemask_epi8(c);
 
             while (d > 0) {

--- a/src/simd_128_u16.h
+++ b/src/simd_128_u16.h
@@ -33,6 +33,8 @@
 
 #include <x86intrin.h>
 
+#include "property.h"
+
 namespace quadiron {
 namespace simd {
 
@@ -311,6 +313,42 @@ inline void butterfly_gs(
         m128i c = sub(a, b, card);
         _buf1[i] = add(a, b, card);
         _buf2[i] = mul(_coef, c, card);
+    }
+}
+
+inline void encode_post_process(
+    vec::Buffers<uint16_t>& output,
+    std::vector<Properties>& props,
+    off_t offset,
+    unsigned code_len,
+    uint16_t threshold,
+    size_t vecs_nb)
+{
+    unsigned vec_size = ALIGN_SIZE / sizeof(uint16_t);
+
+    const m128i _threshold = _mm_set1_epi16(threshold);
+    uint16_t max = 1 << (sizeof(uint16_t) * 8 - 1);
+    const m128i mask_hi = _mm_set1_epi16(max);
+    const unsigned element_size = sizeof(uint16_t);
+
+    for (unsigned frag_id = 0; frag_id < code_len; ++frag_id) {
+        uint16_t* chunk = output.get(frag_id);
+        m128i* buf = reinterpret_cast<m128i*>(chunk);
+        for (unsigned vec_id = 0; vec_id < vecs_nb; ++vec_id) {
+            m128i a = _mm_load_si128(&(buf[vec_id]));
+            m128i b = _mm_cmpeq_epi16(_threshold, a);
+            m128i c = _mm_and_si128(mask_hi, b);
+            uint16_t d = _mm_movemask_epi8(c);
+
+            while (d > 0) {
+                unsigned byte_idx = __builtin_ctz(d);
+                unsigned element_idx = byte_idx / element_size;
+                off_t _offset = offset + vec_id * vec_size + element_idx;
+                const ValueLocation loc(_offset, frag_id);
+                props[frag_id].add(loc, "@");
+                d ^= 1 << byte_idx;
+            }
+        }
     }
 }
 

--- a/src/simd_128_u32.h
+++ b/src/simd_128_u32.h
@@ -358,6 +358,42 @@ inline void butterfly_gs(
     }
 }
 
+inline void encode_post_process(
+    vec::Buffers<uint32_t>& output,
+    std::vector<Properties>& props,
+    off_t offset,
+    unsigned code_len,
+    uint32_t threshold,
+    size_t vecs_nb)
+{
+    const unsigned vec_size = ALIGN_SIZE / sizeof(uint32_t);
+
+    const m128i _threshold = _mm_set1_epi32(threshold);
+    const uint32_t max = 1 << (sizeof(uint32_t) * 8 - 1);
+    const m128i mask_hi = _mm_set1_epi32(max);
+    const unsigned element_size = sizeof(uint32_t);
+
+    for (unsigned frag_id = 0; frag_id < code_len; ++frag_id) {
+        uint32_t* chunk = output.get(frag_id);
+        m128i* buf = reinterpret_cast<m128i*>(chunk);
+        for (unsigned vec_id = 0; vec_id < vecs_nb; ++vec_id) {
+            m128i a = _mm_load_si128(&(buf[vec_id]));
+            m128i b = _mm_cmpeq_epi32(_threshold, a);
+            m128i c = _mm_and_si128(mask_hi, b);
+            uint16_t d = _mm_movemask_epi8(c);
+
+            while (d > 0) {
+                unsigned byte_idx = __builtin_ctz(d);
+                unsigned element_idx = byte_idx / element_size;
+                off_t _offset = offset + vec_id * vec_size + element_idx;
+                const ValueLocation loc(_offset, frag_id);
+                props[frag_id].add(loc, "@");
+                d ^= 1 << byte_idx;
+            }
+        }
+    }
+}
+
 /* ==================== Operations for NF4 =================== */
 
 /** Return aint128 integer from a _m128i register */

--- a/src/simd_128_u32.h
+++ b/src/simd_128_u32.h
@@ -377,9 +377,9 @@ inline void encode_post_process(
         uint32_t* chunk = output.get(frag_id);
         m128i* buf = reinterpret_cast<m128i*>(chunk);
         for (unsigned vec_id = 0; vec_id < vecs_nb; ++vec_id) {
-            m128i a = _mm_load_si128(&(buf[vec_id]));
-            m128i b = _mm_cmpeq_epi32(_threshold, a);
-            m128i c = _mm_and_si128(mask_hi, b);
+            const m128i a = _mm_load_si128(&(buf[vec_id]));
+            const m128i b = _mm_cmpeq_epi32(_threshold, a);
+            const m128i c = _mm_and_si128(mask_hi, b);
             uint16_t d = _mm_movemask_epi8(c);
 
             while (d > 0) {

--- a/src/simd_256_u16.h
+++ b/src/simd_256_u16.h
@@ -311,6 +311,42 @@ inline void butterfly_gs(
     }
 }
 
+inline void encode_post_process(
+    vec::Buffers<uint16_t>& output,
+    std::vector<Properties>& props,
+    off_t offset,
+    unsigned code_len,
+    uint16_t threshold,
+    size_t vecs_nb)
+{
+    unsigned vec_size = ALIGN_SIZE / sizeof(uint16_t);
+
+    const m256i _threshold = _mm256_set1_epi16(threshold);
+    uint16_t max = 1 << (sizeof(uint16_t) * 8 - 1);
+    const m256i mask_hi = _mm256_set1_epi16(max);
+    const unsigned element_size = sizeof(uint16_t);
+
+    for (unsigned frag_id = 0; frag_id < code_len; ++frag_id) {
+        uint16_t* chunk = output.get(frag_id);
+        m256i* buf = reinterpret_cast<m256i*>(chunk);
+        for (unsigned vec_id = 0; vec_id < vecs_nb; ++vec_id) {
+            m256i a = _mm256_load_si256(&(buf[vec_id]));
+            m256i b = _mm256_cmpeq_epi16(_threshold, a);
+            m256i c = _mm256_and_si256(mask_hi, b);
+            uint32_t d = _mm256_movemask_epi8(c);
+
+            while (d > 0) {
+                unsigned byte_idx = __builtin_ctz(d);
+                unsigned element_idx = byte_idx / element_size;
+                off_t _offset = offset + vec_id * vec_size + element_idx;
+                const ValueLocation loc(_offset, frag_id);
+                props[frag_id].add(loc, "@");
+                d ^= 1 << byte_idx;
+            }
+        }
+    }
+}
+
 } // namespace simd
 } // namespace quadiron
 

--- a/src/simd_256_u16.h
+++ b/src/simd_256_u16.h
@@ -330,9 +330,9 @@ inline void encode_post_process(
         uint16_t* chunk = output.get(frag_id);
         m256i* buf = reinterpret_cast<m256i*>(chunk);
         for (unsigned vec_id = 0; vec_id < vecs_nb; ++vec_id) {
-            m256i a = _mm256_load_si256(&(buf[vec_id]));
-            m256i b = _mm256_cmpeq_epi16(_threshold, a);
-            m256i c = _mm256_and_si256(mask_hi, b);
+            const m256i a = _mm256_load_si256(&(buf[vec_id]));
+            const m256i b = _mm256_cmpeq_epi16(_threshold, a);
+            const m256i c = _mm256_and_si256(mask_hi, b);
             uint32_t d = _mm256_movemask_epi8(c);
 
             while (d > 0) {

--- a/src/simd_256_u32.h
+++ b/src/simd_256_u32.h
@@ -377,9 +377,9 @@ inline void encode_post_process(
         uint32_t* chunk = output.get(frag_id);
         m256i* buf = reinterpret_cast<m256i*>(chunk);
         for (unsigned vec_id = 0; vec_id < vecs_nb; ++vec_id) {
-            m256i a = _mm256_load_si256(&(buf[vec_id]));
-            m256i b = _mm256_cmpeq_epi32(_threshold, a);
-            m256i c = _mm256_and_si256(mask_hi, b);
+            const m256i a = _mm256_load_si256(&(buf[vec_id]));
+            const m256i b = _mm256_cmpeq_epi32(_threshold, a);
+            const m256i c = _mm256_and_si256(mask_hi, b);
             uint32_t d = _mm256_movemask_epi8(c);
 
             while (d > 0) {

--- a/src/simd_256_u32.h
+++ b/src/simd_256_u32.h
@@ -358,6 +358,42 @@ inline void butterfly_gs(
     }
 }
 
+inline void encode_post_process(
+    vec::Buffers<uint32_t>& output,
+    std::vector<Properties>& props,
+    off_t offset,
+    unsigned code_len,
+    uint32_t threshold,
+    size_t vecs_nb)
+{
+    const unsigned vec_size = ALIGN_SIZE / sizeof(uint32_t);
+
+    const m256i _threshold = _mm256_set1_epi32(threshold);
+    const uint32_t max = 1 << (sizeof(uint32_t) * 8 - 1);
+    const m256i mask_hi = _mm256_set1_epi32(max);
+    const unsigned element_size = sizeof(uint32_t);
+
+    for (unsigned frag_id = 0; frag_id < code_len; ++frag_id) {
+        uint32_t* chunk = output.get(frag_id);
+        m256i* buf = reinterpret_cast<m256i*>(chunk);
+        for (unsigned vec_id = 0; vec_id < vecs_nb; ++vec_id) {
+            m256i a = _mm256_load_si256(&(buf[vec_id]));
+            m256i b = _mm256_cmpeq_epi32(_threshold, a);
+            m256i c = _mm256_and_si256(mask_hi, b);
+            uint32_t d = _mm256_movemask_epi8(c);
+
+            while (d > 0) {
+                unsigned byte_idx = __builtin_ctz(d);
+                unsigned element_idx = byte_idx / element_size;
+                off_t _offset = offset + vec_id * vec_size + element_idx;
+                const ValueLocation loc(_offset, frag_id);
+                props[frag_id].add(loc, "@");
+                d ^= 1 << byte_idx;
+            }
+        }
+    }
+}
+
 /* ==================== Operations for NF4 =================== */
 typedef __m128i m128i;
 


### PR DESCRIPTION
For FEC over a prime field, the last step of the encoding process is to scan all symbols that are out of range of variable used for output. For example with FEC FNT(65537) with word_size = 2, i.e. variables are of uint16_t type, we scan symbols equal to (q-1) =2^16 that cannot be stored in uint16_t variable in output.

The step is refactored. If SIMD is enabled, it's accelerated using vector operations. Implementations are in the fec_vectorisation.cpp file.