### PR TITLE
Simplify key/value property

### DIFF
--- a/src/fec_base.h
+++ b/src/fec_base.h
@@ -787,14 +787,14 @@ void FecCode<T>::decode_prepare(
     const vec::Vector<T>& fragments_ids = context.get_fragments_id();
     for (unsigned i = 0; i < this->n_data; ++i) {
         const int j = fragments_ids.get(i);
-        auto data = props[j].get(ValueLocation(offset, j));
+        auto data = props[j].get(offset);
 
-        // Check if the symbol is a special case whick is marked by "@".
+        // Check if the symbol is a special case whick is marked by 1, i.e. true
         // Note: this check is necessary when word_size is not large enough to
         // cover all symbols of the field.
         // Following check is used for FFT over FNT where the single special
         // case symbol equals card - 1
-        if (data && *data == "@") {
+        if (data == 1) {
             words.set(i, this->gf->card() - 1);
         }
     }
@@ -1062,17 +1062,17 @@ void FecCode<T>::decode_prepare(
         T* chunk = words.get(i);
         // loop over marked symbols
         for (auto const& data : props[frag_id].get_map()) {
-            off_t loc_offset = data.first.get_offset();
+            off_t loc_offset = data.first;
             if (loc_offset >= offset && loc_offset < offset_max) {
                 // As loc.offset := offset + j
                 const size_t j = (loc_offset - offset);
 
-                // Check if the symbol is a special case whick is marked by "@".
+                // Check if the symbol is a special case whick is marked by 1.
                 // Note: this check is necessary when word_size is not large
                 // enough to cover all symbols of the field. Following check is
                 // used for FFT over FNT where the single special case symbol
                 // equals card - 1
-                if (data.second == "@") {
+                if (data.second == 1) {
                     chunk[j] = thres;
                 }
             }

--- a/src/fec_base.h
+++ b/src/fec_base.h
@@ -74,6 +74,8 @@ static inline uint64_t hrtime_usec(timeval begin)
     return 1000000 * (tv.tv_sec - begin.tv_sec) + tv.tv_usec - begin.tv_usec;
 }
 
+#define OOR_MARK 1
+
 enum class FecType {
     /** Systematic code
      *
@@ -789,12 +791,11 @@ void FecCode<T>::decode_prepare(
         const int j = fragments_ids.get(i);
         auto data = props[j].get(offset);
 
-        // Check if the symbol is a special case whick is marked by 1, i.e. true
-        // Note: this check is necessary when word_size is not large enough to
-        // cover all symbols of the field.
-        // Following check is used for FFT over FNT where the single special
-        // case symbol equals card - 1
-        if (data == 1) {
+        // Check if the symbol is a special case whick is marked by `OOR_MARK`,
+        // i.e. true. Note: this check is necessary when word_size is not large
+        // enough to cover all symbols of the field. Following check is used for
+        // FFT over FNT where the single special case symbol equals card - 1
+        if (data == OOR_MARK) {
             words.set(i, this->gf->card() - 1);
         }
     }
@@ -1067,12 +1068,13 @@ void FecCode<T>::decode_prepare(
                 // As loc.offset := offset + j
                 const size_t j = (loc_offset - offset);
 
-                // Check if the symbol is a special case whick is marked by 1.
+                // Check if the symbol is a special case whick is marked by
+                // `OOR_MARK`.
                 // Note: this check is necessary when word_size is not large
                 // enough to cover all symbols of the field. Following check is
                 // used for FFT over FNT where the single special case symbol
                 // equals card - 1
-                if (data.second == 1) {
+                if (data.second == OOR_MARK) {
                     chunk[j] = thres;
                 }
             }

--- a/src/fec_rs_fnt.h
+++ b/src/fec_rs_fnt.h
@@ -154,7 +154,7 @@ class RsFnt : public FecCode<T> {
         // check for out of range value in output
         for (unsigned i = 0; i < this->code_len; i++) {
             if (output.get(i) & thres) {
-                props[i].add(ValueLocation(offset, i), "@");
+                props[i].add(offset, 1);
                 output.set(i, 0);
             }
         }
@@ -182,9 +182,7 @@ class RsFnt : public FecCode<T> {
             T* chunk = output.get(i);
             for (unsigned j = 0; j < size; ++j) {
                 if (chunk[j] & thres) {
-                    const ValueLocation loc(offset + j, i);
-
-                    props[i].add(loc, "@");
+                    props[i].add(offset + j, 1);
                 }
             }
         }

--- a/src/fec_rs_fnt.h
+++ b/src/fec_rs_fnt.h
@@ -154,7 +154,7 @@ class RsFnt : public FecCode<T> {
         // check for out of range value in output
         for (unsigned i = 0; i < this->code_len; i++) {
             if (output.get(i) & thres) {
-                props[i].add(offset, 1);
+                props[i].add(offset, OOR_MARK);
                 output.set(i, 0);
             }
         }
@@ -182,7 +182,7 @@ class RsFnt : public FecCode<T> {
             T* chunk = output.get(i);
             for (unsigned j = 0; j < size; ++j) {
                 if (chunk[j] & thres) {
-                    props[i].add(offset + j, 1);
+                    props[i].add(offset + j, OOR_MARK);
                 }
             }
         }

--- a/src/fec_rs_gfp_fft.h
+++ b/src/fec_rs_gfp_fft.h
@@ -184,7 +184,7 @@ class RsGfpFft : public FecCode<T> {
         // check for out of range value in output
         for (unsigned i = 0; i < this->code_len; i++) {
             if (output.get(i) >= this->limit_value) {
-                props[i].add(offset, 1);
+                props[i].add(offset, OOR_MARK);
                 output.set(i, output.get(i) % this->limit_value);
             }
         }
@@ -226,10 +226,10 @@ class RsGfpFft : public FecCode<T> {
             const int j = fragments_ids.get(i);
             auto data = props[j].get(offset);
 
-            // Check if the symbol is a special case whick is marked by 1.
-            // In encoded data, its value was subtracted by the predefined
-            // limite_value. This operation restore its value.
-            if (data == 1) {
+            // Check if the symbol is a special case whick is marked by
+            // `OOR_MARK`. In encoded data, its value was subtracted by the
+            // predefined limite_value. This operation restore its value.
+            if (data == OOR_MARK) {
                 words.set(i, words.get(i) + limit_value);
             }
         }

--- a/src/fec_rs_gfp_fft.h
+++ b/src/fec_rs_gfp_fft.h
@@ -184,7 +184,7 @@ class RsGfpFft : public FecCode<T> {
         // check for out of range value in output
         for (unsigned i = 0; i < this->code_len; i++) {
             if (output.get(i) >= this->limit_value) {
-                props[i].add(ValueLocation(offset, i), "@");
+                props[i].add(offset, 1);
                 output.set(i, output.get(i) % this->limit_value);
             }
         }
@@ -224,12 +224,12 @@ class RsGfpFft : public FecCode<T> {
         int k = this->n_data; // number of fragments received
         for (int i = 0; i < k; ++i) {
             const int j = fragments_ids.get(i);
-            auto data = props[j].get(ValueLocation(offset, j));
+            auto data = props[j].get(offset);
 
-            // Check if the symbol is a special case whick is marked by "@".
+            // Check if the symbol is a special case whick is marked by 1.
             // In encoded data, its value was subtracted by the predefined
             // limite_value. This operation restore its value.
-            if (data && *data == "@") {
+            if (data == 1) {
                 words.set(i, words.get(i) + limit_value);
             }
         }

--- a/src/fec_rs_nf4.h
+++ b/src/fec_rs_nf4.h
@@ -153,8 +153,7 @@ class RsNf4 : public FecCode<T> {
             T val = output.get(i);
             ngff4->unpack(val, true_val);
             if (true_val.flag > 0) {
-                props[i].add(
-                    ValueLocation(offset, i), std::to_string(true_val.flag));
+                props[i].add(offset, true_val.flag);
                 // std::cout << "\ni:" << true_val.flag << " at buf" << buf <<
                 // std::endl; std::cout << "encode: val:" << val << " <- " <<
                 // true_val.val << std::endl;
@@ -235,11 +234,10 @@ class RsNf4 : public FecCode<T> {
         int k = this->n_data; // number of fragments received
         for (int i = 0; i < k; ++i) {
             const int j = fragments_ids.get(i);
-            auto data = props[j].get(ValueLocation(offset, j));
+            auto data = props[j].get(offset);
 
             if (data) {
-                uint32_t flag = std::stoul(*data);
-                true_val = ngff4->pack(words.get(i), flag);
+                true_val = ngff4->pack(words.get(i), data);
             } else {
                 true_val = ngff4->pack(words.get(i));
             }
@@ -291,8 +289,8 @@ class RsNf4 : public FecCode<T> {
             for (size_t symb_id = 0; symb_id < size; symb_id++) {
                 ngff4->unpack(chunk[symb_id], true_val);
                 if (true_val.flag > 0) {
-                    const ValueLocation loc(offset + symb_id, frag_id);
-                    props[frag_id].add(loc, std::to_string(true_val.flag));
+                    const off_t loc = offset + symb_id;
+                    props[frag_id].add(loc, true_val.flag);
                 }
                 chunk[symb_id] = true_val.values;
             }
@@ -317,14 +315,13 @@ class RsNf4 : public FecCode<T> {
             std::vector<size_t> packed_symbs;
             // pack marked symbols
             for (auto const& data : props[frag_id].get_map()) {
-                const off_t loc_offset = data.first.get_offset();
+                const off_t loc_offset = data.first;
                 if (loc_offset >= offset && loc_offset < offset_max) {
                     // As loc.offset := offset + j
                     const size_t j = loc_offset - offset;
                     packed_symbs.push_back(j);
                     // pack symbol at index `j`
-                    uint32_t flag = std::stoul(data.second);
-                    chunk[j] = ngff4->pack(chunk[j], flag);
+                    chunk[j] = ngff4->pack(chunk[j], data.second);
                 }
             }
             // sort the list of packed symbols

--- a/src/fec_vectorisation.cpp
+++ b/src/fec_vectorisation.cpp
@@ -67,8 +67,7 @@ void RsFnt<uint16_t>::encode_post_process(
             uint16_t* chunk = output.get(i);
             for (size_t j = vecs_nb * vec_size; j < size; ++j) {
                 if (chunk[j] == threshold) {
-                    const ValueLocation loc(offset + j, i);
-                    props[i].add(loc, "@");
+                    props[i].add(offset + j, 1);
                 }
             }
         }
@@ -100,8 +99,7 @@ void RsFnt<uint32_t>::encode_post_process(
             uint32_t* chunk = output.get(i);
             for (size_t j = vecs_nb * vec_size; j < size; ++j) {
                 if (chunk[j] == threshold) {
-                    const ValueLocation loc(offset + j, i);
-                    props[i].add(loc, "@");
+                    props[i].add(offset + j, 1);
                 }
             }
         }

--- a/src/property.cpp
+++ b/src/property.cpp
@@ -34,18 +34,6 @@
 
 namespace quadiron {
 
-ValueLocation::ValueLocation(const std::string& str)
-{
-    std::istringstream iss(str);
-    std::string buf;
-
-    std::getline(iss, buf, ':');
-    offset = std::stol(buf);
-
-    std::getline(iss, buf);
-    fragment_id = std::stoul(buf);
-}
-
 std::istream& operator>>(std::istream& is, Properties& props)
 {
     std::string line;
@@ -62,7 +50,7 @@ std::istream& operator>>(std::istream& is, Properties& props)
         }
         // Extract the key.
         auto end = line.find('=', begin);
-        std::string key = line.substr(begin, end - begin);
+        auto key = line.substr(begin, end - begin);
         // No leading or trailing whitespace allowed.
         key.erase(key.find_last_not_of(" \f\t\v") + 1);
         // No blank keys allowed
@@ -73,7 +61,7 @@ std::istream& operator>>(std::istream& is, Properties& props)
         begin = line.find_first_not_of(" \f\n\r\t\v", end + 1);
         end = line.find_last_not_of(" \f\n\r\t\v") + 1;
 
-        props.add(ValueLocation(key), line.substr(begin, end - begin));
+        props.add(std::stoul(key), std::stoul(line.substr(begin, end - begin)));
     }
 
     return is;
@@ -82,7 +70,7 @@ std::istream& operator>>(std::istream& is, Properties& props)
 std::ostream& operator<<(std::ostream& os, const Properties& props)
 {
     for (auto& kv : props.props) {
-        os << kv.first.to_string() << " = " << kv.second << '\n';
+        os << kv.first << " = " << kv.second << '\n';
     }
     return os;
 }

--- a/src/property.cpp
+++ b/src/property.cpp
@@ -50,7 +50,7 @@ std::istream& operator>>(std::istream& is, Properties& props)
         }
         // Extract the key.
         auto end = line.find('=', begin);
-        auto key = line.substr(begin, end - begin);
+        std::string key = line.substr(begin, end - begin);
         // No leading or trailing whitespace allowed.
         key.erase(key.find_last_not_of(" \f\t\v") + 1);
         // No blank keys allowed

--- a/src/property.h
+++ b/src/property.h
@@ -57,7 +57,7 @@ class Properties {
         props[loc] = data;
     }
 
-    inline const uint32_t get(const off_t loc) const
+    inline uint32_t get(const off_t loc) const
     {
         auto it = props.find(loc);
         return it != props.end() ? it->second : 0;

--- a/src/property.h
+++ b/src/property.h
@@ -40,77 +40,27 @@
 
 namespace quadiron {
 
-/** The location of a value in a buffer. */
-struct ValueLocation {
-    off_t offset;
-    uint32_t fragment_id;
-
-    /** Construct an invalid location. */
-    ValueLocation() : offset(-1), fragment_id(0) {}
-
-    /** Construct a location from an offset and a fragment ID. */
-    ValueLocation(off_t pos, uint32_t fragment)
-        : offset(pos), fragment_id(fragment)
-    {
-    }
-
-    /** Construct a location from its string representation. */
-    explicit ValueLocation(const std::string& str);
-
-    /**  Checks if the two locations are equal. */
-    bool operator==(const ValueLocation& other) const
-    {
-        return offset == other.offset && fragment_id == other.fragment_id;
-    }
-
-    /** Return the string representation of the location. */
-    std::string to_string() const
-    {
-        std::string str(std::to_string(offset));
-        str += ':';
-        str += std::to_string(fragment_id);
-        return str;
-    }
-
-    inline off_t get_offset() const
-    {
-        return offset;
-    }
-};
-
-} // namespace quadiron
-
-namespace std {
-
-template <>
-struct hash<quadiron::ValueLocation> {
-    std::size_t operator()(const quadiron::ValueLocation& k) const
-    {
-        return std::hash<off_t>()(k.offset)
-               + std::hash<uint32_t>()(k.fragment_id);
-    }
-};
-
-} // namespace std
-
-namespace quadiron {
-
 /** Ancillary data attached to values.
  *
  * A property carries extra-information (whose interpretation is left to the
  * reader) related to a specific value (identified by its location).
+ * It wraps a map whose each element is a key/value where
+ *  - key indicates the location of symbol whose value should be adjusted
+ *  - value indicates value that could be used to adjust the symbol value
+ * For prime fields, value is always 1.
+ * For NF4, value is an uint32_t integer.
  */
 class Properties {
   public:
-    inline void add(const ValueLocation& loc, const std::string& data)
+    inline void add(const off_t loc, const uint32_t data)
     {
         props[loc] = data;
     }
 
-    inline const std::string* const get(const ValueLocation& loc) const
+    inline const uint32_t get(const off_t loc) const
     {
         auto it = props.find(loc);
-        return it != props.end() ? &it->second : nullptr;
+        return it != props.end() ? it->second : 0;
     }
 
     inline void clear()
@@ -118,13 +68,13 @@ class Properties {
         props.clear();
     }
 
-    const std::unordered_map<ValueLocation, std::string>& get_map() const
+    std::unordered_map<off_t, uint32_t> const get_map() const
     {
         return props;
     }
 
   private:
-    std::unordered_map<ValueLocation, std::string> props;
+    std::unordered_map<off_t, uint32_t> props;
 
     friend std::istream& operator>>(std::istream& is, Properties& props);
     friend std::ostream& operator<<(std::ostream& os, const Properties& props);

--- a/src/simd_128_u16.h
+++ b/src/simd_128_u16.h
@@ -344,8 +344,7 @@ inline void encode_post_process(
                 unsigned byte_idx = __builtin_ctz(d);
                 unsigned element_idx = byte_idx / element_size;
                 off_t _offset = offset + vec_id * vec_size + element_idx;
-                const ValueLocation loc(_offset, frag_id);
-                props[frag_id].add(loc, "@");
+                props[frag_id].add(_offset, 1);
                 d ^= 1 << byte_idx;
             }
         }

--- a/src/simd_128_u32.h
+++ b/src/simd_128_u32.h
@@ -386,8 +386,7 @@ inline void encode_post_process(
                 unsigned byte_idx = __builtin_ctz(d);
                 unsigned element_idx = byte_idx / element_size;
                 off_t _offset = offset + vec_id * vec_size + element_idx;
-                const ValueLocation loc(_offset, frag_id);
-                props[frag_id].add(loc, "@");
+                props[frag_id].add(_offset, 1);
                 d ^= 1 << byte_idx;
             }
         }

--- a/src/simd_256_u16.h
+++ b/src/simd_256_u16.h
@@ -339,8 +339,7 @@ inline void encode_post_process(
                 unsigned byte_idx = __builtin_ctz(d);
                 unsigned element_idx = byte_idx / element_size;
                 off_t _offset = offset + vec_id * vec_size + element_idx;
-                const ValueLocation loc(_offset, frag_id);
-                props[frag_id].add(loc, "@");
+                props[frag_id].add(_offset, 1);
                 d ^= 1 << byte_idx;
             }
         }

--- a/src/simd_256_u32.h
+++ b/src/simd_256_u32.h
@@ -386,8 +386,7 @@ inline void encode_post_process(
                 unsigned byte_idx = __builtin_ctz(d);
                 unsigned element_idx = byte_idx / element_size;
                 off_t _offset = offset + vec_id * vec_size + element_idx;
-                const ValueLocation loc(_offset, frag_id);
-                props[frag_id].add(loc, "@");
+                props[frag_id].add(_offset, 1);
                 d ^= 1 << byte_idx;
             }
         }


### PR DESCRIPTION
A property carries extra-information (whose interpretation is left to the reader) related to a specific value (identified by its location).

It wraps a map whose each element is a key/value where
- key indicates the location of symbol whose value should be adjusted
- value is the value that could be used to adjust the symbol value

For prime fields, value is always 1.
For NF4, value is an uint32_t integer.