### PR TITLE
Revert "remove FEC over prime Galois Field"

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -167,6 +167,9 @@ int Benchmark<T>::init()
     case EC_TYPE_RS_GF2N_FFT_ADD:
         fec = new quadiron::fec::RsGf2nFftAdd<T>(word_size, k, m);
         break;
+    case EC_TYPE_RS_GFP_FFT:
+        fec = new quadiron::fec::RsGfpFft<T>(word_size, k, m);
+        break;
     case EC_TYPE_RS_NF4:
         fec = new quadiron::fec::RsNf4<T>(word_size, k, m);
         break;
@@ -279,7 +282,7 @@ int Benchmark<T>::check_params()
     if (sizeof(T) < word_size) {
         return ERR_COMPT_WORD_SIZE_T;
     }
-    if (fec_type == EC_TYPE_RS_FNT) {
+    if (fec_type == EC_TYPE_RS_FNT || fec_type == EC_TYPE_RS_GFP_FFT) {
         if (sizeof(T) <= word_size) {
             return ERR_COMPT_WORD_SIZE_T;
         }
@@ -634,6 +637,7 @@ void xusage()
               << '\n'
               << "\t\t\trs-gf2n-fft-add: "
               << ec_desc.at(EC_TYPE_RS_GF2N_FFT_ADD) << '\n'
+              << "\t\t\trs-gfp-fft: " << ec_desc.at(EC_TYPE_RS_GFP_FFT) << '\n'
               << "\t\t\trs-fnt: " << ec_desc.at(EC_TYPE_RS_FNT) << '\n'
               << "\t\t\trs-nf4: " << ec_desc.at(EC_TYPE_RS_NF4) << '\n'
               << "\t\t\tall: All available Reed-solomon codes\n"

--- a/benchmark/benchmark.h
+++ b/benchmark/benchmark.h
@@ -48,6 +48,7 @@ enum ec_type {
     EC_TYPE_ALL = 0,
     EC_TYPE_RS_FNT,
     EC_TYPE_RS_NF4,
+    EC_TYPE_RS_GFP_FFT,
     EC_TYPE_RS_GF2N_FFT_ADD,
     EC_TYPE_RS_GF2N_V,
     EC_TYPE_RS_GF2N_C,
@@ -64,6 +65,7 @@ const std::map<ec_type, std::string> ec_desc = {
     {EC_TYPE_RS_GF2N_FFT, "Reed-solomon codes over GF(2^n) using FFT"},
     {EC_TYPE_RS_GF2N_FFT_ADD,
      "Reed-solomon codes over GF(2^n) using additive FFT"},
+    {EC_TYPE_RS_GFP_FFT, "Reed-solomon codes over GF(p) using FFT"},
     {EC_TYPE_RS_FNT, "Reed-solomon codes over GF(p = Fermat number) using FFT"},
     {EC_TYPE_RS_NF4,
      "Reed-solomon codes over GF(65537) using FFT on pack of codewords"},
@@ -76,6 +78,7 @@ const std::map<ec_type, std::string> ec_desc_short = {
     {EC_TYPE_RS_GF2N_C, "rs-gf2n-c"},
     {EC_TYPE_RS_GF2N_FFT, "rs-gf2n-fft"},
     {EC_TYPE_RS_GF2N_FFT_ADD, "rs-gf2n-fft-add"},
+    {EC_TYPE_RS_GFP_FFT, "rs-gfp-fft"},
     {EC_TYPE_RS_FNT, "rs-fnt"},
     {EC_TYPE_RS_NF4, "rs-nf4"},
 };
@@ -115,6 +118,7 @@ const std::map<std::string, ec_type> fec_type_map = {
     {"rs-gf2n-c", EC_TYPE_RS_GF2N_C},
     {"rs-gf2n-fft", EC_TYPE_RS_GF2N_FFT},
     {"rs-gf2n-fft-add", EC_TYPE_RS_GF2N_FFT_ADD},
+    {"rs-gfp-fft", EC_TYPE_RS_GFP_FFT},
     {"rs-fnt", EC_TYPE_RS_FNT},
     {"rs-nf4", EC_TYPE_RS_NF4},
 };
@@ -255,6 +259,8 @@ struct Params_t {
         if (sizeof_T == -1) {
             if (fec_type == EC_TYPE_RS_NF4) {
                 sizeof_T = (((word_size - 1) / 2) + 1) * 4;
+            } else if (fec_type == EC_TYPE_RS_GFP_FFT && word_size == 4) {
+                sizeof_T = 8;
             } else {
                 sizeof_T = (((word_size - 1) / 4) + 1) * 4;
             }

--- a/scripts/test_ec.sh
+++ b/scripts/test_ec.sh
@@ -147,7 +147,7 @@ do_test()
     echo
 }
 
-for i in rs-fnt_1 rs-fnt_2 rs-nf4_2 rs-nf4_4 rs-nf4_8 rs-gf2n-fft_1 rs-gf2n-fft_2 rs-gf2n-fft_4 rs-gf2n-fft_8 rs-gf2n-fft-add_1 rs-gf2n-fft-add_2 rs-gf2n-fft-add_4 rs-gf2n-fft-add_8 rs-gf2n-v_1 rs-gf2n-v_2 rs-gf2n-c_1 rs-gf2n-c_2 rs-gf2n-v_4 rs-gf2n-v_8 rs-gf2n-v_16 rs-gf2n-c_4 rs-gf2n-c_8 rs-gf2n-c_16
+for i in rs-fnt_1 rs-fnt_2 rs-nf4_2 rs-nf4_4 rs-nf4_8 rs-gfp-fft_1 rs-gfp-fft_2 rs-gfp-fft_4 rs-gf2n-fft_1 rs-gf2n-fft_2 rs-gf2n-fft_4 rs-gf2n-fft_8 rs-gf2n-fft-add_1 rs-gf2n-fft-add_2 rs-gf2n-fft-add_4 rs-gf2n-fft-add_8 rs-gf2n-v_1 rs-gf2n-v_2 rs-gf2n-c_1 rs-gf2n-c_2 rs-gf2n-v_4 rs-gf2n-v_8 rs-gf2n-v_16 rs-gf2n-c_4 rs-gf2n-c_8 rs-gf2n-c_16
 do
     fec_type=$(echo $i|cut -d_ -f1)
     word_size=$(echo $i|cut -d_ -f2)

--- a/src/fec_rs_gfp_fft.h
+++ b/src/fec_rs_gfp_fft.h
@@ -1,0 +1,238 @@
+/* -*- mode: c++ -*- */
+/*
+ * Copyright 2017-2018 Scality
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __QUAD_FEC_RS_GFP_FFT_H__
+#define __QUAD_FEC_RS_GFP_FFT_H__
+
+#include "arith.h"
+#include "fec_base.h"
+#include "fft_2n.h"
+#include "fft_base.h"
+#include "fft_ct.h"
+#include "gf_prime.h"
+#include "vec_vector.h"
+#include "vec_zero_ext.h"
+
+namespace quadiron {
+namespace fec {
+
+/** Reed-Solomon (RS) Erasure code over prime Galois Fields and FFT.
+ *
+ * @note Necessary condition: p ≥ 2<sup>8*word_size</sup> to cover all
+ * possible values of symbols, as each symbol is 8*word_size bits.
+ *
+ * A length-k vector X is encoded into a length-n vector Y whose elements are
+ * GF(p) elements. Hence, elements of Y could be greater than
+ * 2<sup>8*word_size</sup>
+ *
+ * We can deal with this as below.
+ *
+ * @note To facilitate our implementation, we choose
+ *   p < 2 * 2<sup>8*word_size</sup>.
+ *
+ * Supposing that an element Y[i] > 2<sup>8*word_size</sup>, we will store its
+ * value modulo 2<sup>8*word_size</sup>, i.e.
+ *
+ *   Y<sub>p</sub>[i] = Y[i] % 2<sup>8*word_size</sup>
+ *
+ * A flag will be used to mark the position `i`.
+ *
+ * To decode X, we read Y[i] from Y<sub>p</sub>[i] as:
+ *
+ *    Y[i] = Y<sub>p</sub>[i] + 2<sup>8*word_size</sup>
+ *
+ * Because p < 2 * 2<sup>8*word_size</sup>, a single bool is enough as flag.
+ */
+template <typename T>
+class RsGfpFft : public FecCode<T> {
+  public:
+    RsGfpFft(unsigned word_size, unsigned n_data, unsigned n_parities)
+        : FecCode<T>(FecType::NON_SYSTEMATIC, word_size, n_data, n_parities)
+    {
+        this->fec_init();
+    }
+
+    inline void check_params() override {}
+
+    inline void init_gf() override
+    {
+        // warning all fermat numbers >= to F_5 (2^32+1) are composite!!!
+        T gf_p = 0;
+        if (this->word_size < 4) {
+            gf_p = (1ULL << (8 * this->word_size)) + 1;
+            this->limit_value = (1ULL << (8 * this->word_size));
+        } else if (this->word_size == 4) {
+            gf_p = (T)4294991873ULL;              // p-1=2^13 29^1 101^1 179^1
+            this->limit_value = (T)4294967296ULL; // 2^32
+        } else {
+            assert(false); // not support yet
+            exit(1);
+        }
+
+        assert(gf_p >= this->limit_value);
+        // we choose gf_p for a simple implementation
+        assert(gf_p / 2 < this->limit_value);
+
+        this->gf = std::unique_ptr<gf::Field<T>>(new gf::Prime<T>(gf_p));
+        assert(
+            arith::jacobi<T>(this->gf->get_primitive_root(), this->gf->card())
+            == -1);
+    }
+
+    inline void init_fft() override
+    {
+        // with this encoder we cannot exactly satisfy users request, we need to
+        // pad n = minimal divisor of (q-1) that is at least (n_parities +
+        // n_data)
+        this->n =
+            this->gf->get_code_len_high_compo(this->n_parities + this->n_data);
+
+        // compute root of order n-1 such as r^(n-1) mod q == 1
+        this->r = this->gf->get_nth_root(this->n);
+
+        if (arith::is_power_of_2<T>(this->n)) {
+            this->fft = std::unique_ptr<fft::Radix2<T>>(
+                new fft::Radix2<T>(*(this->gf), this->n));
+            this->fft_full = std::unique_ptr<fft::Radix2<T>>(
+                new fft::Radix2<T>(*(this->gf), this->n));
+        } else {
+            this->fft = std::unique_ptr<fft::CooleyTukey<T>>(
+                new fft::CooleyTukey<T>(*(this->gf), this->n));
+            this->fft_full = std::unique_ptr<fft::CooleyTukey<T>>(
+                new fft::CooleyTukey<T>(*(this->gf), this->n));
+        }
+
+        unsigned len_2k = this->gf->get_code_len_high_compo(2 * this->n_data);
+        if (arith::is_power_of_2<T>(len_2k)) {
+            this->fft_2k = std::unique_ptr<fft::Radix2<T>>(
+                new fft::Radix2<T>(*(this->gf), len_2k, len_2k));
+        } else {
+            this->fft_2k = std::unique_ptr<fft::CooleyTukey<T>>(
+                new fft::CooleyTukey<T>(*(this->gf), len_2k, len_2k));
+        }
+    }
+
+    inline void init_others() override
+    {
+        // vector stores r^{-i} for i = 0, ... , k
+        T inv_r = this->gf->inv(this->r);
+        this->inv_r_powers = std::unique_ptr<vec::Vector<T>>(
+            new vec::Vector<T>(*(this->gf), this->n_data + 1));
+        for (unsigned i = 0; i <= this->n_data; i++)
+            this->inv_r_powers->set(i, this->gf->exp(inv_r, i));
+
+        // vector stores r^{i} for i = 0, ... , k
+        this->r_powers = std::unique_ptr<vec::Vector<T>>(
+            new vec::Vector<T>(*(this->gf), this->n));
+        for (unsigned i = 0; i < this->n; i++) {
+            this->r_powers->set(i, this->gf->exp(this->r, i));
+        }
+    }
+
+    int get_n_outputs() override
+    {
+        return this->n;
+    }
+
+    /**
+     * Encode vector
+     *
+     * @param output must be n
+     * @param props must be exactly n
+     * @param offset used to locate special values
+     * @param words must be n_data
+     */
+    void encode(
+        vec::Vector<T>* output,
+        std::vector<Properties>& props,
+        off_t offset,
+        vec::Vector<T>* words) override
+    {
+        vec::ZeroExtended<T> vwords(words, this->n);
+        this->fft->fft(output, &vwords);
+        // check for out of range value in output
+        for (unsigned i = 0; i < this->code_len; i++) {
+            if (output->get(i) >= this->limit_value) {
+                props[i].add(ValueLocation(offset, i), "@");
+                output->set(i, output->get(i) % this->limit_value);
+            }
+        }
+    }
+
+    void decode_add_data(int fragment_index, int row) override
+    {
+        // not applicable
+        assert(false);
+    }
+
+    void decode_add_parities(int fragment_index, int row) override
+    {
+        // we can't anticipate here
+    }
+
+    void decode_build() override
+    {
+        // nothing to do
+    }
+
+  private:
+    // fft::FourierTransform<T>* fft = nullptr;
+    T limit_value;
+
+  protected:
+    /* Prepare for decoding
+     * It supports for FEC using multiplicative FFT over FNT
+     */
+    void decode_prepare(
+        const DecodeContext<T>& context,
+        const std::vector<Properties>& props,
+        off_t offset,
+        vec::Vector<T>* words) override
+    {
+        const vec::Vector<T>& fragments_ids = context.get_fragments_id();
+        int k = this->n_data; // number of fragments received
+        for (int i = 0; i < k; ++i) {
+            const int j = fragments_ids.get(i);
+            auto data = props[j].get(ValueLocation(offset, j));
+
+            // Check if the symbol is a special case whick is marked by "@".
+            // In encoded data, its value was subtracted by the predefined
+            // limite_value. This operation restore its value.
+            if (data && *data == "@") {
+                words->set(i, words->get(i) + limit_value);
+            }
+        }
+    }
+};
+
+} // namespace fec
+} // namespace quadiron
+
+#endif

--- a/src/quadiron.h
+++ b/src/quadiron.h
@@ -43,6 +43,7 @@
 #include "fec_rs_gf2n.h"
 #include "fec_rs_gf2n_fft.h"
 #include "fec_rs_gf2n_fft_add.h"
+#include "fec_rs_gfp_fft.h"
 #include "fec_rs_nf4.h"
 #include "fft_2.h"
 #include "fft_2n.h"

--- a/test/fec_utest.cpp
+++ b/test/fec_utest.cpp
@@ -94,6 +94,25 @@ class FECUtest {
         run_test(&fec, fec.n, n_data, n_data + n_parities);
     }
 
+    void test_fec_rs_gfp_fft()
+    {
+        std::cout << "Test fec::RsGfpFft with sizeof(T)=" << sizeof(T) << '\n';
+        for (size_t word_size = 1; word_size <= 4 && word_size < sizeof(T);
+             word_size *= 2) {
+            test_fec_rs_gfp_fft_with_word_size(word_size);
+        }
+    }
+    void test_fec_rs_gfp_fft_with_word_size(int word_size)
+    {
+        std::cout << "Test fec::RsGfpFft with word size=" << word_size << '\n';
+
+        unsigned n_data = 3;
+        unsigned n_parities = 3;
+
+        quadiron::fec::RsGfpFft<T> fec(word_size, n_data, n_parities);
+        run_test(&fec, fec.n, n_data, n_data + n_parities, true);
+    }
+
     void run_test(
         quadiron::fec::FecCode<T>* fec,
         int n,
@@ -146,6 +165,7 @@ class FECUtest {
         test_fec_rs_nf4();
         test_fec_rs_gf2n_fft();
         test_fec_rs_gf2n_fft_add();
+        test_fec_rs_gfp_fft();
     }
 };
 


### PR DESCRIPTION
This reverts commit 82dae76071a60ddc8fc2ba8b066a32d77f6149e9.

RsGfpFft shouldn't be removed, only Polynomial and gf::Extension were
targeted.