### PR TITLE
Slight enhancement

### DIFF
--- a/src/gf_ring.h
+++ b/src/gf_ring.h
@@ -396,19 +396,20 @@ inline void RingModN<T>::mul_vec_to_vecp(
     int n = u.get_n();
     size_t len = src.get_size();
     T h = this->card_minus_one();
+    const std::vector<T*>& src_mem = src.get_mem();
+    const std::vector<T*>& dest_mem = dest.get_mem();
+    T* coef_vec = u.get_mem();
     for (i = 0; i < n; i++) {
-        T coef = u.get(i);
-        T* _src = src.get(i);
-        T* _dest = dest.get(i);
-        if (coef == 0) {
-            dest.fill(i, 0);
+        T coef = coef_vec[i];
+        if (coef > 1 && coef < h) {
+            this->mul_coef_to_buf(coef, src_mem[i], dest_mem[i], len);
         } else if (coef == 1) {
-            dest.copy(i, _src);
+            dest.copy(i, src_mem[i]);
+        } else if (coef == 0) {
+            dest.fill(i, 0);
         } else if (coef == h) {
-            dest.copy(i, _src);
-            this->neg(len, _dest);
-        } else if (coef > 1) {
-            this->mul_coef_to_buf(coef, _src, _dest, len);
+            dest.copy(i, src_mem[i]);
+            this->neg(len, dest_mem[i]);
         }
     }
 }

--- a/src/vec_cast.h
+++ b/src/vec_cast.h
@@ -51,13 +51,10 @@ inline void pack_next(
     int n,
     size_t size)
 {
-    int i;
-    std::vector<Tw*> tmp(n, nullptr);
-    for (i = 0; i < n; i++) {
-        tmp[i] = reinterpret_cast<Tw*>(src.at(i));
-        std::copy_n(tmp[i], size, dest.at(i));
+    for (int i = 0; i < n; i++) {
+        Tw* tmp = reinterpret_cast<Tw*>(src.at(i));
+        std::copy_n(tmp, size, dest.at(i));
     }
-    tmp.shrink_to_fit();
 }
 
 /*
@@ -85,16 +82,24 @@ inline void pack(
     assert(sizeof(Td) >= word_size);
     assert(word_size % sizeof(Ts) == 0);
     // get only word_size bytes from each element
-    if (word_size == 1) {
+    switch (word_size) {
+    case 1:
         pack_next<Ts, Td, uint8_t>(src, dest, n, size);
-    } else if (word_size == 2) {
+        break;
+    case 2:
         pack_next<Ts, Td, uint16_t>(src, dest, n, size);
-    } else if (word_size == 4) {
+        break;
+    case 4:
         pack_next<Ts, Td, uint32_t>(src, dest, n, size);
-    } else if (word_size == 8) {
+        break;
+    case 8:
         pack_next<Ts, Td, uint64_t>(src, dest, n, size);
-    } else if (word_size == 16) {
+        break;
+    case 16:
         pack_next<Ts, Td, __uint128_t>(src, dest, n, size);
+        break;
+    default:
+        break;
     }
 }
 
@@ -105,13 +110,10 @@ inline void unpack_next(
     int n,
     size_t size)
 {
-    int i;
-    std::vector<Tw*> tmp(n, nullptr);
-    for (i = 0; i < n; i++) {
-        tmp[i] = reinterpret_cast<Tw*>(dest.at(i));
-        std::copy_n(src.at(i), size, tmp[i]);
+    for (int i = 0; i < n; i++) {
+        Tw* tmp = reinterpret_cast<Tw*>(dest.at(i));
+        std::copy_n(src.at(i), size, tmp);
     }
-    tmp.shrink_to_fit();
 }
 
 /*
@@ -139,16 +141,24 @@ inline void unpack(
     assert(sizeof(Ts) >= word_size);
     assert(word_size % sizeof(Td) == 0);
     // get only word_size bytes from each element
-    if (word_size == 1) {
+    switch (word_size) {
+    case 1:
         unpack_next<Ts, Td, uint8_t>(src, dest, n, size);
-    } else if (word_size == 2) {
+        break;
+    case 2:
         unpack_next<Ts, Td, uint16_t>(src, dest, n, size);
-    } else if (word_size == 4) {
+        break;
+    case 4:
         unpack_next<Ts, Td, uint32_t>(src, dest, n, size);
-    } else if (word_size == 8) {
+        break;
+    case 8:
         unpack_next<Ts, Td, uint64_t>(src, dest, n, size);
-    } else if (word_size == 16) {
+        break;
+    case 16:
         unpack_next<Ts, Td, __uint128_t>(src, dest, n, size);
+        break;
+    default:
+        break;
     }
 }
 

--- a/test/fec_utest.cpp
+++ b/test/fec_utest.cpp
@@ -129,16 +129,28 @@ TYPED_TEST_CASE(FecTestNo128, No128);
 
 TYPED_TEST(FecTestNo128, TestFnt) // NOLINT
 {
-    fec::RsFnt<TypeParam> fec(
-        fec::FecType::NON_SYSTEMATIC, 2, this->n_data, this->n_parities);
-    this->run_test(fec, this->n_data, this->n_data + this->n_parities, true);
+    for (unsigned word_size = 1; word_size <= 2; ++word_size) {
+        fec::RsFnt<TypeParam> fec(
+            fec::FecType::NON_SYSTEMATIC,
+            word_size,
+            this->n_data,
+            this->n_parities);
+        this->run_test(
+            fec, this->n_data, this->n_data + this->n_parities, true);
+    }
 }
 
 TYPED_TEST(FecTestNo128, TestFntSys) // NOLINT
 {
-    fec::RsFnt<TypeParam> fec(
-        fec::FecType::SYSTEMATIC, 2, this->n_data, this->n_parities);
-    this->run_test(fec, this->n_data, this->n_data + this->n_parities, true);
+    for (unsigned word_size = 1; word_size <= 2; ++word_size) {
+        fec::RsFnt<TypeParam> fec(
+            fec::FecType::SYSTEMATIC,
+            word_size,
+            this->n_data,
+            this->n_parities);
+        this->run_test(
+            fec, this->n_data, this->n_data + this->n_parities, true);
+    }
 }
 
 TYPED_TEST(FecTestNo128, TestGfpFft) // NOLINT


### PR DESCRIPTION
- Systematic RS-FNT: decode intermediate symbols using Radix-2 FFT on a shorten-length input
- Pack/unpack: don't need to create temporary vectors
- Enhance slightly the multiplication of a vector to a Buffers to avoid as much as possible multiplying two numbers
- FEC utest: add test for FNT with word size = 1 and 2