### PR TITLE
experimental using openMP for encode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ include(CheckCXXCompilerFlag)
 set(COMMON_CXX_FLAGS
   -pipe
   -Wall
+  -fopenmp 
 )
 
 # Option for enabling/disabling SIMD flags is for both of debug and release

--- a/src/fft_2n.h
+++ b/src/fft_2n.h
@@ -31,6 +31,8 @@
 #ifndef __QUAD_FFT_2N_H__
 #define __QUAD_FFT_2N_H__
 
+#include <omp.h>
+
 #include "arith.h"
 #include "fft_2.h"
 #include "fft_base.h"
@@ -197,6 +199,7 @@ void Radix2<T>::fft(vec::Vector<T>& output, vec::Vector<T>& input)
     const unsigned group_len =
         (input_len > data_len) ? len / input_len : len / data_len;
 
+#pragma omp parallel for
     for (unsigned idx = 0; idx < input_len; ++idx) {
         // set output  = scramble(input), i.e. bit reversal ordering
         const T a = input.get(idx);
@@ -205,6 +208,7 @@ void Radix2<T>::fft(vec::Vector<T>& output, vec::Vector<T>& input)
             output.set(i, a);
         }
     }
+#pragma omp parallel for
     for (unsigned idx = input_len; idx < data_len; ++idx) {
         // set output  = scramble(input), i.e. bit reversal ordering
         const unsigned end = rev[idx] + group_len;
@@ -216,6 +220,7 @@ void Radix2<T>::fft(vec::Vector<T>& output, vec::Vector<T>& input)
     for (unsigned m = group_len; m < len; m *= 2) {
         const unsigned doubled_m = 2 * m;
         const unsigned ratio = len / doubled_m;
+#pragma omp parallel for
         for (unsigned j = 0; j < m; ++j) {
             const T r = W->get(j * ratio);
             for (unsigned i = j; i < len; i += doubled_m) {
@@ -249,6 +254,7 @@ void Radix2<T>::fft_inv(vec::Vector<T>& output, vec::Vector<T>& input)
 
     for (unsigned m = len / 2; m >= 1; m /= 2) {
         unsigned doubled_m = 2 * m;
+#pragma omp parallel for
         for (unsigned j = 0; j < m; ++j) {
             T r = inv_W->get(j * len / doubled_m);
             for (unsigned i = j; i < len; i += doubled_m) {
@@ -290,6 +296,7 @@ void Radix2<T>::fft(vec::Buffers<T>& output, vec::Buffers<T>& input)
     const unsigned group_len =
         (input_len > data_len) ? len / input_len : len / data_len;
 
+#pragma omp parallel for           
     for (unsigned idx = 0; idx < input_len; ++idx) {
         // set output  = scramble(input), i.e. bit reversal ordering
         T* a = input.get(idx);
@@ -298,6 +305,7 @@ void Radix2<T>::fft(vec::Buffers<T>& output, vec::Buffers<T>& input)
             output.copy(i, a);
         }
     }
+#pragma omp parallel for           
     for (unsigned idx = input_len; idx < data_len; ++idx) {
         // set output  = scramble(input), i.e. bit reversal ordering
         const unsigned end = rev[idx] + group_len;
@@ -308,6 +316,7 @@ void Radix2<T>::fft(vec::Buffers<T>& output, vec::Buffers<T>& input)
     // perform butterfly operations
     for (unsigned m = group_len; m < len; m *= 2) {
         const unsigned doubled_m = 2 * m;
+#pragma omp parallel for           
         for (unsigned j = 0; j < m; ++j) {
             const T r = W->get(j * len / doubled_m);
             for (unsigned i = j; i < len; i += doubled_m) {
@@ -344,6 +353,7 @@ void Radix2<T>::fft_inv(vec::Buffers<T>& output, vec::Buffers<T>& input)
     bit_rev_permute(output);
 
     unsigned i;
+#pragma omp parallel for    
     for (i = 0; i < input_len; ++i) {
         output.copy(i, input.get(i));
     }
@@ -353,6 +363,7 @@ void Radix2<T>::fft_inv(vec::Buffers<T>& output, vec::Buffers<T>& input)
 
     for (unsigned m = len / 2; m >= 1; m /= 2) {
         unsigned doubled_m = 2 * m;
+#pragma omp parallel for    
         for (unsigned j = 0; j < m; ++j) {
             T r = inv_W->get(j * len / doubled_m);
             for (unsigned i = j; i < len; i += doubled_m) {


### PR DESCRIPTION
FIX #249 

I was playing with openMP and encode speed, and just by doing this, on my 2-core VirtualBox I was able to double the speed of the encode basically as shown in those 2 measures:

Without:
```
54: rs-fnt_W1_N50_M50_D_C_NON_SYSTEMATIC,GEN,enc,11682,dec,0,
54: rs-fnt_W1_N3_M3_D_C_NON_SYSTEMATIC,GEN,enc,446,dec,0,REP,enc,371,dec,1748777,
54: rs-fnt_W1_N3_M3_D0-1_C0_NON_SYSTEMATIC,GEN,enc,531,dec,0,REP,enc,345,dec,1683961,
54: rs-fnt_W1_N3_M5_D0-1_C0_NON_SYSTEMATIC,GEN,enc,415,dec,0,REP,enc,306,dec,1859003,
54: rs-fnt_W1_N3_M3_D1-2_C2_NON_SYSTEMATIC,GEN,enc,342,dec,0,REP,enc,282,dec,1702904,
54: rs-fnt_W1_N9_M3_D1-2_C2_NON_SYSTEMATIC,GEN,enc,1015,dec,0,REP,enc,974,dec,7980070,
54: rs-fnt_W1_N9_M3_D2-3_C2_NON_SYSTEMATIC,GEN,enc,1140,dec,0,REP,enc,970,dec,7672327,
54: rs-fnt_W1_N9_M5_D2-3-4_C2-3_NON_SYSTEMATIC,GEN,enc,1014,dec,0,REP,enc,1021,dec,7717734,
54: rs-fnt_W1_N9_M5_D1-3-5_C1-3_NON_SYSTEMATIC,GEN,enc,1050,dec,0,REP,enc,961,dec,7620345,
54: rs-fnt_W1_N9_M5_D1-3-5-7-8_C_NON_SYSTEMATIC,GEN,enc,1058,dec,0,REP,enc,1003,dec,7513444,
54: rs-fnt_W1_N9_M5_D_C0-1-2-3-4_NON_SYSTEMATIC,GEN,enc,1030,dec,0,REP,enc,1053,dec,7828909,
54: rs-fnt_W2_N50_M50_D_C_NON_SYSTEMATIC,GEN,enc,5331,dec,0,
54: rs-fnt_W2_N3_M3_D_C_NON_SYSTEMATIC,GEN,enc,160,dec,0,REP,enc,119,dec,623762,
54: rs-fnt_W2_N3_M3_D0-1_C0_NON_SYSTEMATIC,GEN,enc,137,dec,0,REP,enc,121,dec,622016,
54: rs-fnt_W2_N3_M5_D0-1_C0_NON_SYSTEMATIC,GEN,enc,311,dec,0,REP,enc,132,dec,626148,
54: rs-fnt_W2_N3_M3_D1-2_C2_NON_SYSTEMATIC,GEN,enc,119,dec,0,REP,enc,117,dec,636176,
54: rs-fnt_W2_N9_M3_D1-2_C2_NON_SYSTEMATIC,GEN,enc,530,dec,0,REP,enc,457,dec,3159750,
54: rs-fnt_W2_N9_M3_D2-3_C2_NON_SYSTEMATIC,GEN,enc,454,dec,0,REP,enc,487,dec,3222815,
54: rs-fnt_W2_N9_M5_D2-3-4_C2-3_NON_SYSTEMATIC,GEN,enc,474,dec,0,REP,enc,473,dec,3207778,
54: rs-fnt_W2_N9_M5_D1-3-5_C1-3_NON_SYSTEMATIC,GEN,enc,486,dec,0,REP,enc,456,dec,3105525,
54: rs-fnt_W2_N9_M5_D1-3-5-7-8_C_NON_SYSTEMATIC,GEN,enc,471,dec,0,REP,enc,450,dec,3158596,
54: rs-fnt_W2_N9_M5_D_C0-1-2-3-4_NON_SYSTEMATIC,GEN,enc,458,dec,0,REP,enc,463,dec,3284101,
```
With:
```
54: rs-fnt_W1_N50_M50_D_C_NON_SYSTEMATIC,GEN,enc,6379,dec,0,
54: rs-fnt_W1_N3_M3_D_C_NON_SYSTEMATIC,GEN,enc,292,dec,0,REP,enc,218,dec,1513485,
54: rs-fnt_W1_N3_M3_D0-1_C0_NON_SYSTEMATIC,GEN,enc,536,dec,0,REP,enc,205,dec,1622537,
54: rs-fnt_W1_N3_M5_D0-1_C0_NON_SYSTEMATIC,GEN,enc,570,dec,0,REP,enc,224,dec,1536442,
54: rs-fnt_W1_N3_M3_D1-2_C2_NON_SYSTEMATIC,GEN,enc,521,dec,0,REP,enc,235,dec,1527373,
54: rs-fnt_W1_N9_M3_D1-2_C2_NON_SYSTEMATIC,GEN,enc,946,dec,0,REP,enc,804,dec,5863211,
54: rs-fnt_W1_N9_M3_D2-3_C2_NON_SYSTEMATIC,GEN,enc,769,dec,0,REP,enc,736,dec,6125558,
54: rs-fnt_W1_N9_M5_D2-3-4_C2-3_NON_SYSTEMATIC,GEN,enc,767,dec,0,REP,enc,751,dec,5942816,
54: rs-fnt_W1_N9_M5_D1-3-5_C1-3_NON_SYSTEMATIC,GEN,enc,784,dec,0,REP,enc,737,dec,5957581,
54: rs-fnt_W1_N9_M5_D1-3-5-7-8_C_NON_SYSTEMATIC,GEN,enc,786,dec,0,REP,enc,728,dec,5824002,
54: rs-fnt_W1_N9_M5_D_C0-1-2-3-4_NON_SYSTEMATIC,GEN,enc,791,dec,0,REP,enc,735,dec,5762718,
54: rs-fnt_W2_N50_M50_D_C_NON_SYSTEMATIC,GEN,enc,4052,dec,0,
54: rs-fnt_W2_N3_M3_D_C_NON_SYSTEMATIC,GEN,enc,306,dec,0,REP,enc,141,dec,576822,
54: rs-fnt_W2_N3_M3_D0-1_C0_NON_SYSTEMATIC,GEN,enc,134,dec,0,REP,enc,84,dec,581018,
54: rs-fnt_W2_N3_M5_D0-1_C0_NON_SYSTEMATIC,GEN,enc,148,dec,0,REP,enc,83,dec,520250,
54: rs-fnt_W2_N3_M3_D1-2_C2_NON_SYSTEMATIC,GEN,enc,88,dec,0,REP,enc,84,dec,521601,
54: rs-fnt_W2_N9_M3_D1-2_C2_NON_SYSTEMATIC,GEN,enc,326,dec,0,REP,enc,332,dec,2191755,
54: rs-fnt_W2_N9_M3_D2-3_C2_NON_SYSTEMATIC,GEN,enc,338,dec,0,REP,enc,313,dec,2350386,
54: rs-fnt_W2_N9_M5_D2-3-4_C2-3_NON_SYSTEMATIC,GEN,enc,349,dec,0,REP,enc,326,dec,2253370,
54: rs-fnt_W2_N9_M5_D1-3-5_C1-3_NON_SYSTEMATIC,GEN,enc,362,dec,0,REP,enc,325,dec,2271510,
54: rs-fnt_W2_N9_M5_D1-3-5-7-8_C_NON_SYSTEMATIC,GEN,enc,348,dec,0,REP,enc,355,dec,2175632,
54: rs-fnt_W2_N9_M5_D_C0-1-2-3-4_NON_SYSTEMATIC,GEN,enc,345,dec,0,REP,enc,328,dec,2279095,
```
I assume using it on 4 cores with quadruple the speed, etc

There is a little bit more work due to breaks that will require using shared conditions, but parallelizing the decode is feasible because there are a lot of for loops.

I think more and more this is the right approach for threading this lib (indeed using threads will involve using thread pools and can complexify the code, etc).

We nevertheless need to have a clean implem in case the pragma is not supported by the compiler.