### PR TITLE
Try to enhance performance of FNT(257)

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -45,13 +45,23 @@ fi
 chunk_size=51200
 # for rs-fnt with different packet sizes
 word_size=2
-for ec_type in rs-fnt rs-fnt-sys; do
-  for k in 16; do
-    for n in 256 1024; do
-      m=$((n-k))
-      for pkt_size in 256 512 1024; do
-        ${bin} -e ${ec_type} -w ${word_size} -k ${k} -m ${m} -c ${chunk_size} -s ${sce_type} -g ${threads_nb} -f ${show_type} -p ${pkt_size} -n ${samples_nb}
-      done
+for word_size in 1 2; do
+    for type_size in 2 4; do
+        max_len=$((256**word_size))
+        if ((type_size>word_size)); then
+            for ec_type in rs-fnt rs-fnt-sys; do
+              for k in 16 64; do
+                for n in 32 256 1024; do
+                  if ((n<max_len)) && ((n>k)); then
+                    m=$((n-k))
+                    for pkt_size in 512; do
+                      ${bin} -e ${ec_type} -w ${word_size} -t ${type_size} -k ${k} -m ${m} -c ${chunk_size} -s ${sce_type} -g ${threads_nb} -f ${show_type} -p ${pkt_size} -n ${samples_nb}
+                    show_type=0
+                    done
+                  fi
+                done
+              done
+            done
+        fi
     done
-  done
 done

--- a/src/fec_context.h
+++ b/src/fec_context.h
@@ -41,6 +41,7 @@
 #include "fft_base.h"
 #include "gf_base.h"
 #include "gf_nf4.h"
+#include "property.h"
 #include "vec_poly.h"
 #include "vec_zero_ext.h"
 
@@ -67,12 +68,14 @@ class DecodeContext {
         fft::FourierTransform<T>& fft,
         fft::FourierTransform<T>& fft_2k,
         const vec::Vector<T>& fragments_ids,
+        std::vector<Properties>& input_props,
         const vec::Vector<T>& vx,
         const int k,
         const int n,
         int vx_zero = -1,
         const size_t size = 0,
         vec::Buffers<T>* output = nullptr)
+        : props_indices(input_props.size(), 0)
     {
         this->k = k;
         this->n = n;
@@ -86,6 +89,12 @@ class DecodeContext {
         this->max_n_2k = (this->n > this->len_2k) ? this->n : this->len_2k;
 
         this->fragments_ids = &fragments_ids;
+
+        for (auto& props : input_props) {
+            // Sort properties on the basis of location of pairs in ascending
+            // order.
+            props.sort();
+        }
 
         A = std::make_unique<vec::Poly<T>>(gf, n);
         A_fft_2k = std::make_unique<vec::Vector<T>>(gf, len_2k);
@@ -266,6 +275,7 @@ class DecodeContext {
 
   public:
     int vx_zero;
+    std::vector<size_t> props_indices;
 
   private:
     unsigned k;

--- a/src/fec_rs_fnt.h
+++ b/src/fec_rs_fnt.h
@@ -148,8 +148,9 @@ class RsFnt : public FecCode<T> {
             suffix_words = std::make_unique<vec::Buffers<T>>(
                 this->n - this->n_data - this->n_outputs, this->pkt_size);
 
+            std::vector<Properties> dummy_props;
             enc_context = this->init_context_dec(
-                *enc_frag_ids, this->pkt_size, inter_words.get());
+                *enc_frag_ids, dummy_props, this->pkt_size, inter_words.get());
 
             // for decoding
             this->dec_inter_codeword =
@@ -197,7 +198,7 @@ class RsFnt : public FecCode<T> {
     }
 
     void decode_data(
-        const DecodeContext<T>& context,
+        DecodeContext<T>& context,
         vec::Buffers<T>& output,
         vec::Buffers<T>& words)
     {

--- a/src/fec_rs_gf2n.h
+++ b/src/fec_rs_gf2n.h
@@ -135,7 +135,7 @@ class RsGf2n : public FecCode<T> {
     }
 
     void decode(
-        const DecodeContext<T>&,
+        DecodeContext<T>&,
         vec::Vector<T>& output,
         const std::vector<Properties>&,
         off_t,
@@ -144,8 +144,11 @@ class RsGf2n : public FecCode<T> {
         decode_mat->mul(&output, &words);
     }
 
-    std::unique_ptr<DecodeContext<T>>
-    init_context_dec(vec::Vector<T>&, size_t, vec::Buffers<T>*) override
+    std::unique_ptr<DecodeContext<T>> init_context_dec(
+        vec::Vector<T>&,
+        std::vector<Properties>&,
+        size_t,
+        vec::Buffers<T>*) override
     {
         std::unique_ptr<DecodeContext<T>> context;
         return context;

--- a/src/fec_rs_gf2n_fft.h
+++ b/src/fec_rs_gf2n_fft.h
@@ -128,7 +128,7 @@ class RsGf2nFft : public FecCode<T> {
     }
 
     void decode_prepare(
-        const DecodeContext<T>&,
+        DecodeContext<T>&,
         const std::vector<Properties>&,
         off_t,
         vec::Vector<T>&) override

--- a/src/fec_rs_gf2n_fft_add.h
+++ b/src/fec_rs_gf2n_fft_add.h
@@ -120,6 +120,7 @@ class RsGf2nFftAdd : public FecCode<T> {
   protected:
     std::unique_ptr<DecodeContext<T>> init_context_dec(
         vec::Vector<T>& fragments_ids,
+        std::vector<Properties>& input_props,
         size_t,
         vec::Buffers<T>*) override
     {
@@ -149,6 +150,7 @@ class RsGf2nFftAdd : public FecCode<T> {
                 *fft,
                 *(this->fft_2k),
                 fragments_ids,
+                input_props,
                 vx,
                 this->n_data,
                 this->n,
@@ -158,7 +160,7 @@ class RsGf2nFftAdd : public FecCode<T> {
     }
 
     void decode_prepare(
-        const DecodeContext<T>&,
+        DecodeContext<T>&,
         const std::vector<Properties>&,
         off_t,
         vec::Vector<T>&) override
@@ -167,7 +169,7 @@ class RsGf2nFftAdd : public FecCode<T> {
     }
 
     void decode_apply(
-        const DecodeContext<T>& context,
+        DecodeContext<T>& context,
         vec::Vector<T>& output,
         vec::Vector<T>& words) override
     {

--- a/src/fec_rs_gfp_fft.h
+++ b/src/fec_rs_gfp_fft.h
@@ -209,7 +209,7 @@ class RsGfpFft : public FecCode<T> {
      * It supports for FEC using multiplicative FFT over FNT
      */
     void decode_prepare(
-        const DecodeContext<T>& context,
+        DecodeContext<T>& context,
         const std::vector<Properties>& props,
         off_t offset,
         vec::Vector<T>& words) override
@@ -218,13 +218,14 @@ class RsGfpFft : public FecCode<T> {
         int k = this->n_data; // number of fragments received
         for (int i = 0; i < k; ++i) {
             const int j = fragments_ids.get(i);
-            auto data = props[j].get(offset);
-
-            // Check if the symbol is a special case whick is marked by
-            // `OOR_MARK`. In encoded data, its value was subtracted by the
-            // predefined limite_value. This operation restore its value.
-            if (data == OOR_MARK) {
-                words.set(i, words.get(i) + limit_value);
+            if (props[j].is_marked(context.props_indices[j], offset)) {
+                // Check if the symbol is a special case whick is marked by
+                // `OOR_MARK`. In encoded data, its value was subtracted by the
+                // predefined limite_value. This operation restore its value.
+                if (props[j].marker(context.props_indices[j]) == OOR_MARK) {
+                    words.set(i, words.get(i) + limit_value);
+                }
+                context.props_indices.at(j)++;
             }
         }
     }

--- a/src/property.cpp
+++ b/src/property.cpp
@@ -69,8 +69,10 @@ std::istream& operator>>(std::istream& is, Properties& props)
 
 std::ostream& operator<<(std::ostream& os, const Properties& props)
 {
-    for (auto& kv : props.props) {
-        os << kv.first << " = " << kv.second << '\n';
+    const std::vector<std::pair<size_t, uint32_t>> map = props.get_map();
+
+    for (auto const& item : map) {
+        os << item.first << " = " << item.second << '\n';
     }
     return os;
 }

--- a/test/fec_utest.cpp
+++ b/test/fec_utest.cpp
@@ -84,7 +84,7 @@ class FecTestCommon : public ::testing::Test {
                 received_frags.set(i, encoded_frags.get(ids.at(i)));
             }
             std::unique_ptr<fec::DecodeContext<T>> context =
-                fec.init_context_dec(fragments_ids);
+                fec.init_context_dec(fragments_ids, props);
 
             fec.decode(*context, decoded_frags, props, 0, received_frags);
 


### PR DESCRIPTION
- It focuses on improving performance of FNT(257)

- Use two vectors instead of unordered_map: one vector for locations, the other for marked values.

- I tried to use `reserve()` for unordered_map`, it improves about 10% for encoding
  The use of two vectors improves 1.5-2x on encoding speeds. And a significant enhancement is observed for decoding.
   
   
