### PR TITLE
Build Release mode with enabled SIMD by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           name: Compile on ARM64 with the NDK
           command: >
             rm -rf build && mkdir build && cd build &&
-            cmake -G 'Unix Makefiles' -DCMAKE_AR=/arm64/bin/aarch64-linux-android-ar -DCMAKE_BUILD_TYPE=Debug .. &&
+            cmake -G 'Unix Makefiles' -DCMAKE_AR=/arm64/bin/aarch64-linux-android-ar -DCMAKE_BUILD_TYPE=Debug -DUSE_SIMD=OFF .. &&
             make
   test:
     docker:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ file(MAKE_DIRECTORY ${GENERATE_DIR})
 ##################
 # Setting for SIMD
 ##################
-set(USE_SIMD "OFF" CACHE STRING "SIMD vectorization")
+set(USE_SIMD "ON" CACHE STRING "SIMD vectorization")
 set_property(CACHE USE_SIMD PROPERTY STRINGS OFF ON SSE AVX)
 
 ####################
@@ -95,7 +95,7 @@ set_property(CACHE USE_SIMD PROPERTY STRINGS OFF ON SSE AVX)
 # Set a default build type if none was specified.
 set(default_build_type "Release")
 if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
-  set(default_build_type "Debug")
+  set(default_build_type "Release")
 endif()
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
Observing a timeout test in liberasurecodes'  unit test, we could avoid such cases by using Release + SIMD mode by default