### PR TITLE
Buffers stores data and meta

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -42,6 +42,10 @@ template <typename Type>
 struct DoubleSize {
 };
 template <>
+struct DoubleSize<uint8_t> {
+    typedef uint16_t T;
+};
+template <>
 struct DoubleSize<uint16_t> {
     typedef uint32_t T;
 };
@@ -60,6 +64,10 @@ struct DoubleSize<__uint128_t> {
 
 template <typename Type>
 struct SignedDoubleSize {
+};
+template <>
+struct SignedDoubleSize<uint8_t> {
+    typedef int16_t T;
 };
 template <>
 struct SignedDoubleSize<uint16_t> {

--- a/src/fec_base.h
+++ b/src/fec_base.h
@@ -1349,7 +1349,7 @@ void FecCode<T>::decode(
     if (type == FecType::SYSTEMATIC) {
         this->fft->fft(*dec_inter_codeword, output);
         for (unsigned i = 0; i < this->n_data; i++) {
-            output.copy(i, dec_inter_codeword->get(i));
+            output.copy(*dec_inter_codeword, i, i);
         }
     }
 }

--- a/src/fft_2n.h
+++ b/src/fft_2n.h
@@ -152,7 +152,7 @@ class Radix2 : public FourierTransform<T> {
     size_t simd_trailing_len;
     size_t simd_offset;
 
-    std::unique_ptr<T[]> rev = nullptr;
+    std::vector<T> rev;
     std::unique_ptr<vec::Vector<T>> W = nullptr;
     std::unique_ptr<vec::Vector<T>> inv_W = nullptr;
     T* vec_W;
@@ -192,7 +192,7 @@ Radix2<T>::Radix2(const gf::Field<T>& gf, int n, int data_len, size_t pkt_size)
     card = this->gf->card();
     card_minus_one = this->gf->card_minus_one();
 
-    rev = std::unique_ptr<T[]>(new T[n]);
+    rev.reserve(n);
     init_bitrev();
 
     // Indices used for accelerated functions
@@ -361,21 +361,7 @@ void Radix2<T>::fft(vec::Buffers<T>& output, vec::Buffers<T>& input)
     const unsigned group_len =
         (input_len > data_len) ? len / input_len : len / data_len;
 
-    const std::vector<T*>& i_mem = input.get_mem();
-    const std::vector<T*>& o_mem = output.get_mem();
-
-    for (unsigned idx = 0; idx < input_len; ++idx) {
-        // set output  = scramble(input), i.e. bit reversal ordering
-        for (unsigned i = rev[idx]; i < rev[idx] + group_len; ++i) {
-            memcpy(o_mem[i], i_mem[idx], buf_size);
-        }
-    }
-    for (unsigned idx = input_len; idx < data_len; ++idx) {
-        // set output  = scramble(input), i.e. bit reversal ordering
-        for (unsigned i = rev[idx]; i < rev[idx] + group_len; ++i) {
-            memset(o_mem[i], 0, buf_size);
-        }
-    }
+    output.radix2_fft_prepare(input, rev, data_len, group_len);
 
     // ----------------------
     // Two layers at a time
@@ -513,38 +499,29 @@ void Radix2<T>::fft_inv(vec::Buffers<T>& output, vec::Buffers<T>& input)
     bit_rev_permute(output);
 
     // copy input to output
-    const std::vector<T*>& i_mem = input.get_mem();
-    const std::vector<T*>& o_mem = output.get_mem();
-    unsigned i;
-    for (i = 0; i < input_len; ++i) {
-        memcpy(o_mem[i], i_mem[i], buf_size);
-    }
+    output.radix2_fft_inv_prepare(input);
 
     unsigned m = len / 2;
+    unsigned doubled_m = len;
 
     if (input_len < len) {
-        const unsigned input_len_power_2 = arith::ceil2<unsigned>(input_len);
-        for (; i < input_len_power_2; ++i) {
-            memset(o_mem[i], 0, buf_size);
-        }
-
         // For Q are zeros only => Q = c * P
         for (; m >= input_len; m /= 2) {
-            unsigned doubled_m = 2 * m;
             for (unsigned j = 0; j < m; ++j) {
                 const T r = inv_W->get(j * len / doubled_m);
                 butterfly_gs_step_simple(output, r, j, m, doubled_m);
             }
+            doubled_m = m;
         }
     }
 
     // Next, normal butterlfy GS is performed
     for (; m >= 1; m /= 2) {
-        unsigned doubled_m = 2 * m;
         for (unsigned j = 0; j < m; ++j) {
             const T r = inv_W->get(j * len / doubled_m);
             butterfly_gs_step(output, r, j, m, doubled_m);
         }
+        doubled_m = m;
     }
 
     // 2nd reversion of elements of output to return its natural order

--- a/src/fft_single.h
+++ b/src/fft_single.h
@@ -89,9 +89,9 @@ void Single<T>::ifft(vec::Vector<T>& output, vec::Vector<T>& input)
 template <typename T>
 void Single<T>::fft(vec::Buffers<T>& output, vec::Buffers<T>& input)
 {
-    T* buf = input.get(0);
-    for (int i = 0; i < this->n; i++)
-        output.copy(i, buf);
+    for (int i = 0; i < this->n; i++) {
+        output.copy(input, 0, i);
+    }
 }
 
 /*
@@ -109,7 +109,7 @@ template <typename T>
 void Single<T>::ifft(vec::Buffers<T>& output, vec::Buffers<T>& input)
 {
     output.zero_fill();
-    output.copy(0, input.get(0));
+    output.copy(input, 0, 0);
 }
 
 } // namespace fft

--- a/src/gf_ring.h
+++ b/src/gf_ring.h
@@ -390,11 +390,11 @@ inline void RingModN<T>::mul_vec_to_vecp(
         if (coef > 1 && coef < h) {
             this->mul_coef_to_buf(coef, src_mem[i], dest_mem[i], len);
         } else if (coef == 1) {
-            dest.copy(i, src_mem[i]);
+            dest.copy(src, i, i);
         } else if (coef == 0) {
             dest.fill(i, 0);
         } else if (coef == h) {
-            dest.copy(i, src_mem[i]);
+            dest.copy(src, i, i);
             this->neg(len, dest_mem[i]);
         }
     }

--- a/src/vec_buffers.h
+++ b/src/vec_buffers.h
@@ -109,25 +109,22 @@ class Buffers final {
     ~Buffers();
     int get_n(void) const;
     size_t get_size(void) const;
-    int get_mem_len(void);
+    size_t get_mem_len(void);
     void zero_fill(void);
     void fill(int i, T value);
-    void set(int i, T* buf);
     T* get(int i);
     const T* get(int i) const;
     const std::vector<T*>& get_mem() const;
     void set_mem(std::vector<T*>* mem);
     void copy(const Buffers<T>& v);
     void copy(int i, T* buf);
-    void separate_even_odd();
-    void separate_even_odd(Buffers<T>& even, Buffers<T>& odd);
     friend bool operator==<T>(const Buffers<T>& lhs, const Buffers<T>& rhs);
     void dump(void);
     void swap(unsigned i, unsigned j);
 
   protected:
     std::vector<T*> mem;
-    int mem_len;
+    size_t mem_len;
     size_t size;
     int n;
 
@@ -353,7 +350,7 @@ inline size_t Buffers<T>::get_size(void) const
 }
 
 template <typename T>
-inline int Buffers<T>::get_mem_len(void)
+inline size_t Buffers<T>::get_mem_len(void)
 {
     return mem_len;
 }
@@ -369,17 +366,6 @@ template <typename T>
 void Buffers<T>::fill(int i, T value)
 {
     std::fill_n(mem[i], size, value);
-}
-
-template <typename T>
-inline void Buffers<T>::set(int i, T* buf)
-{
-    assert(i >= 0 && i < n);
-
-    if ((mem_alloc_case == BufMemAlloc::NONE) && (mem[i] != nullptr))
-        this->allocator.deallocate(mem[i], size);
-
-    mem[i] = buf;
 }
 
 template <typename T>
@@ -422,33 +408,6 @@ template <typename T>
 void Buffers<T>::copy(int i, T* buf)
 {
     std::copy_n(buf, this->size, mem[i]);
-}
-
-template <typename T>
-void Buffers<T>::separate_even_odd()
-{
-    std::vector<T*> _mem(n, nullptr);
-    int half = n / 2;
-    int j = 0;
-    int i;
-    for (i = 0; i < n; i += 2) {
-        _mem[j] = get(i);            // even
-        _mem[j + half] = get(i + 1); // odd
-        j++;
-    }
-    for (i = 0; i < n; i++) {
-        mem[i] = _mem[i];
-    }
-    _mem.shrink_to_fit();
-}
-
-template <typename T>
-void Buffers<T>::separate_even_odd(Buffers<T>& even, Buffers<T>& odd)
-{
-    for (int i = 0, j = 0; i < n; i += 2, ++j) {
-        even.set(j, get(i));
-        odd.set(j, get(i + 1));
-    }
 }
 
 template <typename T>

--- a/test/buffers_utest.cpp
+++ b/test/buffers_utest.cpp
@@ -38,9 +38,21 @@ namespace vec = quadiron::vec;
 namespace gf = quadiron::gf;
 
 template <typename T>
+bool is_all_zeros(const T* buf, size_t len)
+{
+    for (size_t i = 0; i < len; ++i) {
+        if (buf[i] != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+template <typename T>
 class BuffersTest : public ::testing::Test {
   public:
     quadiron::simd::AlignedAllocator<T> allocator;
+    quadiron::simd::AlignedAllocator<uint8_t> allocator_meta;
 
     BuffersTest()
     {
@@ -49,19 +61,27 @@ class BuffersTest : public ::testing::Test {
     ~BuffersTest() = default;
 
     std::unique_ptr<vec::Buffers<T>>
-    gen_buffers_rand_data(int n, int size, int _max = 0)
+    gen_buffers_rand_data(int n, int size, bool has_meta = false, int _max = 0)
     {
-        T max_val = 65537;
-        const int max = (_max == 0) ? max_val : _max;
-        std::uniform_int_distribution<uint32_t> dis(0, max - 1);
-        auto vec = std::make_unique<vec::Buffers<T>>(n, size);
+        const T max = (_max == 0) ? std::numeric_limits<T>::max() : _max;
+        std::uniform_int_distribution<T> dis(0, max - 1);
+        auto vec = std::make_unique<vec::Buffers<T>>(n, size, has_meta);
 
+        const std::vector<T*> mem = vec->get_mem();
         for (int i = 0; i < n; i++) {
-            T* buf = this->allocator.allocate(size);
             for (int j = 0; j < size; j++) {
-                buf[j] = dis(quadiron::prng());
+                mem[i][j] = dis(quadiron::prng());
             }
-            vec->set(i, buf);
+        }
+
+        if (has_meta) {
+            const std::vector<uint8_t*> meta = vec->get_meta();
+            const size_t meta_size = vec->get_meta_size();
+            for (int i = 0; i < n; ++i) {
+                for (size_t j = 0; j < meta_size; ++j) {
+                    meta[i][j] = static_cast<uint8_t>(dis(quadiron::prng()));
+                }
+            }
         }
 
         return vec;
@@ -85,21 +105,6 @@ class BuffersTest : public ::testing::Test {
         return vec;
     }
 
-    bool check_eq(const T* buf1, const T* buf2, size_t len)
-    {
-        return memcmp(buf1, buf2, len * sizeof(T)) == 0;
-    }
-
-    bool check_all_zeros(const T* buf, size_t len)
-    {
-        for (size_t i = 0; i < len; ++i) {
-            if (buf[i] != 0) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     bool check_shuffled_bufs(
         const vec::Buffers<T>& input,
         const vec::Buffers<T>& output,
@@ -114,7 +119,17 @@ class BuffersTest : public ::testing::Test {
         std::vector<bool> check(output.get_n(), false);
 
         for (unsigned i = 0; i < map_len; ++i) {
-            if (!check_eq(input.get(i), output.get(map.get(i)), size)) {
+            if (!std::equal(
+                    input.get(i),
+                    input.get(i) + size,
+                    output.get(map.get(i)))) {
+                return false;
+            }
+            if (input.has_meta()
+                && !std::equal(
+                       input.get_meta(i),
+                       input.get_meta(i) + input.get_meta_size(),
+                       output.get_meta(map.get(i)))) {
                 return false;
             }
             check[map.get(i)] = true;
@@ -124,7 +139,12 @@ class BuffersTest : public ::testing::Test {
         if (output_len > input_len) {
             for (size_t i = 0; i < output_len; ++i) {
                 if (!check[i]) {
-                    if (!check_all_zeros(output.get(i), size)) {
+                    if (!is_all_zeros(output.get(i), size)) {
+                        return false;
+                    }
+                    if (input.has_meta()
+                        && !is_all_zeros(
+                               output.get_meta(i), output.get_meta_size())) {
                         return false;
                     }
                 }
@@ -135,97 +155,88 @@ class BuffersTest : public ::testing::Test {
     }
 };
 
-using TestedTypes = ::testing::Types<uint32_t, uint64_t>;
+using TestedTypes = ::testing::Types<uint8_t, uint16_t, uint32_t, uint64_t>;
 TYPED_TEST_CASE(BuffersTest, TestedTypes);
 
 TYPED_TEST(BuffersTest, TestConstructors) // NOLINT
 {
-    const int n = 16;
-    const int begin = 5;
-    const int end = 12;
-    const int size = 4;
+    const std::vector<bool> tests = {true, false};
 
-    auto vec1 = this->gen_buffers_rand_data(n, size);
-    vec::Buffers<TypeParam> vec2(*vec1, begin, end);
+    for (bool const& has_meta : tests) {
+        const int n = 16;
+        const int begin = 5;
+        const int end = 12;
+        const int size = 4;
 
-    const std::vector<TypeParam*> mem1 = vec1->get_mem();
-    const std::vector<TypeParam*> mem2 = vec2.get_mem();
+        auto vec1 = this->gen_buffers_rand_data(n, size, has_meta);
+        ASSERT_EQ(has_meta, vec1->has_meta());
 
-    ASSERT_EQ(vec2.get_n(), end - begin);
-    ASSERT_EQ(vec2.get_size(), vec1->get_size());
+        const size_t meta_size = vec1->get_meta_size();
 
-    for (int i = 0; i < end - begin; i++) {
-        for (int j = 0; j < size; j++) {
-            mem2.at(i)[j] = mem1.at(i + begin)[j];
+        vec::Buffers<TypeParam> vec2(*vec1, begin, end);
+
+        const std::vector<TypeParam*> mem1 = vec1->get_mem();
+        const std::vector<TypeParam*> mem2 = vec2.get_mem();
+
+        // Check Slice constructor
+        ASSERT_EQ(vec2.get_n(), end - begin);
+        ASSERT_EQ(vec2.get_size(), vec1->get_size());
+        for (int i = begin, j = 0; i < end; ++i, ++j) {
+            ASSERT_TRUE(std::equal(mem1[i], mem1[i] + size, mem2[j]));
         }
-    }
 
-    std::vector<TypeParam*> mem3(end - begin, nullptr);
-    for (int i = 0; i < end - begin; i++) {
-        mem3[i] = mem1.at(i + begin);
-    }
-    vec::Buffers<TypeParam> vec3(end - begin, size, mem3);
+        if (has_meta) {
+            ASSERT_EQ(vec2.has_meta(), vec1->has_meta());
+            ASSERT_EQ(vec2.get_meta_size(), meta_size);
 
-    ASSERT_EQ(vec2, vec3);
+            const std::vector<uint8_t*> meta1 = vec1->get_meta();
+            const std::vector<uint8_t*> meta2 = vec2.get_meta();
 
-    auto gf(gf::create<gf::Prime<TypeParam>>(65537));
-
-    // no-extension
-    const int out_n_1 = n - 5;
-    auto map_1 = this->gen_rand_vector(gf, out_n_1, out_n_1);
-    vec::Buffers<TypeParam> vec4(*vec1, *map_1, out_n_1);
-    ASSERT_TRUE(this->check_shuffled_bufs(*vec1, vec4, *map_1));
-
-    // extension
-    const int out_n_2 = n + 10;
-    auto map_2 = this->gen_rand_vector(gf, n, out_n_2);
-    vec::Buffers<TypeParam> vec5(*vec1, *map_2, out_n_2);
-    ASSERT_TRUE(this->check_shuffled_bufs(*vec1, vec5, *map_2));
-}
-
-TYPED_TEST(BuffersTest, TestEvenOddSeparation) // NOLINT
-{
-    const int n = 8;
-    const int size = 32;
-    const int half = n / 2;
-    auto vec1 = this->gen_buffers_rand_data(n, size);
-    vec::Buffers<TypeParam> vec2(n, size);
-
-    vec2.copy(*vec1);
-
-    std::vector<TypeParam*>* even_mem =
-        new std::vector<TypeParam*>(half, nullptr);
-    std::vector<TypeParam*>* odd_mem =
-        new std::vector<TypeParam*>(half, nullptr);
-    vec::Buffers<TypeParam> i_even(half, size, *even_mem);
-    vec::Buffers<TypeParam> i_odd(half, size, *odd_mem);
-    vec1->separate_even_odd(i_even, i_odd);
-
-    vec1->separate_even_odd();
-
-    vec::Buffers<TypeParam> _i_even(*vec1, 0, half);
-    vec::Buffers<TypeParam> _i_odd(*vec1, half, n);
-    ASSERT_EQ(i_even, _i_even);
-    ASSERT_EQ(i_odd, _i_odd);
-
-    const std::vector<TypeParam*> mem1 = vec1->get_mem();
-    const std::vector<TypeParam*> mem2 = vec2.get_mem();
-
-    bool ok = true;
-    for (int i = 0; i < n / 2; i += 2) {
-        TypeParam* even1 = mem1.at(i);
-        TypeParam* even2 = mem2.at(i * 2);
-        TypeParam* odd1 = mem1.at(i + n / 2);
-        TypeParam* odd2 = mem2.at(i * 2 + 1);
-        for (int j = 0; j < size; j++) {
-            if (even1[j] != even2[j] || odd1[j] != odd2[j]) {
-                ok = false;
-                i = n;
-                break;
+            for (int i = begin, j = 0; i < end; ++i, ++j) {
+                ASSERT_TRUE(
+                    std::equal(meta1[i], meta1[i] + meta_size, meta2[j]));
             }
         }
+
+        // Check constructor from given mem and meta
+        std::vector<TypeParam*> mem3(end - begin);
+        for (int i = 0; i < end - begin; i++) {
+            mem3[i] = this->allocator.allocate(size);
+            std::copy_n(mem1[i + begin], size, mem3[i]);
+        }
+
+        if (has_meta) {
+            const std::vector<uint8_t*> meta1 = vec1->get_meta();
+            std::vector<uint8_t*> meta3(end - begin);
+            for (int i = 0; i < end - begin; i++) {
+                meta3[i] = this->allocator_meta.allocate(meta_size);
+                std::copy_n(meta1[i + begin], meta_size, meta3[i]);
+            }
+
+            vec::Buffers<TypeParam> vec3(end - begin, size, mem3, &meta3);
+
+            ASSERT_EQ(vec2, vec3);
+
+        } else {
+            vec::Buffers<TypeParam> vec3(end - begin, size, mem3);
+
+            ASSERT_EQ(vec2, vec3);
+        }
+
+        auto gf(gf::create<gf::Prime<TypeParam>>(static_cast<TypeParam>(31)));
+
+        // no-extension
+        const int out_n_1 = n - 5;
+        auto map_1 = this->gen_rand_vector(gf, out_n_1, out_n_1);
+        vec::Buffers<TypeParam> vec4(*vec1, *map_1, out_n_1);
+        ASSERT_TRUE(this->check_shuffled_bufs(*vec1, vec4, *map_1));
+
+        // extension
+        const int out_n_2 = n + 10;
+        auto map_2 = this->gen_rand_vector(gf, n, out_n_2);
+        vec::Buffers<TypeParam> vec5(*vec1, *map_2, out_n_2);
+        ASSERT_TRUE(this->check_shuffled_bufs(*vec1, vec5, *map_2));
     }
-    ASSERT_TRUE(ok);
 }
 
 TYPED_TEST(BuffersTest, TestZeroExtented) // NOLINT
@@ -235,23 +246,32 @@ TYPED_TEST(BuffersTest, TestZeroExtented) // NOLINT
     const int n1 = 4;
     const int n2 = 10;
 
-    auto vec = this->gen_buffers_rand_data(n, size);
-    vec::Buffers<TypeParam> vec1(*vec, n1);
-    vec::Buffers<TypeParam> vec2(*vec, n2);
+    const std::vector<bool> tests = {true, false};
 
-    vec::Buffers<TypeParam> _vec1(*vec, 0, n1);
-    vec::Buffers<TypeParam> _vec2(*vec, n2);
+    for (bool const& has_meta : tests) {
+        auto vec = this->gen_buffers_rand_data(n, size, has_meta);
+        // cloned constructor: no zero-padding as `n1 < n`
+        vec::Buffers<TypeParam> vec1(*vec, n1);
+        // cloned constructor: there are zero-padding as `n2 > n`
+        vec::Buffers<TypeParam> vec2(*vec, n2);
 
-    ASSERT_EQ(vec1, _vec1);
-    ASSERT_EQ(vec2, _vec2);
+        // slice from `vec` as `n1 < n`
+        vec::Buffers<TypeParam> _vec1(*vec, 0, n1);
+        // slice and zero-extended from `vec` as `n2 > n`
+        vec::Buffers<TypeParam> _vec2(*vec, 0, n2);
 
-    vec::Buffers<TypeParam> vec3(vec2, n1);
-    ASSERT_EQ(vec3, vec1);
+        ASSERT_EQ(vec1, _vec1);
+        ASSERT_EQ(vec2, _vec2);
+
+        vec::Buffers<TypeParam> vec3(vec2, n);
+        ASSERT_EQ(vec3, *vec);
+    }
 }
 
 TYPED_TEST(BuffersTest, TestPackUnpack) // NOLINT
 {
     const int iter_count = quadiron::arith::log2<TypeParam>(sizeof(TypeParam));
+    const std::vector<bool> tests = {true, false};
 
     for (int i = 0; i <= iter_count; i++) {
         const int word_size = quadiron::arith::exp2<TypeParam>(i);
@@ -259,41 +279,54 @@ TYPED_TEST(BuffersTest, TestPackUnpack) // NOLINT
         const int size = 32;
         const int bytes_size = size * word_size;
         const TypeParam max = (static_cast<TypeParam>(1) << word_size) + 1;
-        auto words = this->gen_buffers_rand_data(n, size, max);
-        const std::vector<TypeParam*> mem_T = words->get_mem();
 
-        // Pack manually from TypeParam to uint8_t.
-        vec::Buffers<uint8_t> vec_char(n, bytes_size);
-        const std::vector<uint8_t*> mem_char = vec_char.get_mem();
-        for (int j = 0; j < n; j++) {
-            int t = 0;
-            TypeParam* buf_T = mem_T.at(j);
-            uint8_t* buf_char = mem_char.at(j);
+        for (bool const& has_meta : tests) {
+            auto words = this->gen_buffers_rand_data(n, size, has_meta, max);
 
-            for (int k = 0; k < size; k++) {
-                TypeParam symb = buf_T[k];
-                buf_char[t] = static_cast<uint8_t>(symb & 0xFF);
+            const std::vector<TypeParam*> mem_T = words->get_mem();
 
-                t++;
-                for (int u = 1; u < word_size; u++) {
-                    symb >>= 8;
+            // Pack manually from TypeParam to uint8_t.
+            vec::Buffers<uint8_t> vec_char(n, bytes_size);
+            const std::vector<uint8_t*> mem_char = vec_char.get_mem();
+            for (int j = 0; j < n; j++) {
+                int t = 0;
+                TypeParam* buf_T = mem_T.at(j);
+                uint8_t* buf_char = mem_char.at(j);
+
+                for (int k = 0; k < size; k++) {
+                    TypeParam symb = buf_T[k];
                     buf_char[t] = static_cast<uint8_t>(symb & 0xFF);
+
                     t++;
+                    for (int u = 1; u < word_size; u++) {
+                        symb = static_cast<TypeParam>(symb) >> 8;
+                        buf_char[t] = static_cast<uint8_t>(symb & 0xFF);
+                        t++;
+                    }
                 }
             }
+
+            // Pack bufs of type uint8_t to bufs of type TypeParam.
+            vec::Buffers<TypeParam> vec_T_tmp(n, size);
+            const std::vector<TypeParam*> mem_T_tmp = vec_T_tmp.get_mem();
+
+            vec::pack<uint8_t, TypeParam>(
+                mem_char, mem_T_tmp, n, size, word_size);
+
+            // Unpack bufs of type TypeParam to bufs of type uint8_t.
+            vec::Buffers<uint8_t> vec_char_tmp(n, bytes_size);
+            const std::vector<uint8_t*> mem_char_tmp = vec_char_tmp.get_mem();
+            vec::unpack<TypeParam, uint8_t>(
+                mem_T_tmp, mem_char_tmp, n, size, word_size);
+
+            for (int i = 0; i < n; ++i) {
+                ASSERT_TRUE(
+                    std::equal(mem_T_tmp[i], mem_T_tmp[i] + size, mem_T[i]));
+                ASSERT_TRUE(std::equal(
+                    mem_char_tmp[i],
+                    mem_char_tmp[i] + bytes_size,
+                    mem_char[i]));
+            }
         }
-
-        // Pack bufs of type uint8_t to bufs of type TypeParam.
-        vec::Buffers<TypeParam> vec_T_tmp(n, size);
-        const std::vector<TypeParam*> mem_T_tmp = vec_T_tmp.get_mem();
-        vec::pack<uint8_t, TypeParam>(mem_char, mem_T_tmp, n, size, word_size);
-        ASSERT_EQ(vec_T_tmp, *words);
-
-        // Unpack bufs of type TypeParam to bufs of type uint8_t.
-        vec::Buffers<uint8_t> vec_char_tmp(n, bytes_size);
-        const std::vector<uint8_t*> mem_char_tmp = vec_char_tmp.get_mem();
-        vec::unpack<TypeParam, uint8_t>(
-            mem_T_tmp, mem_char_tmp, n, size, word_size);
-        ASSERT_EQ(vec_char_tmp, vec_char);
     }
 }


### PR DESCRIPTION
`Buffers` consists of a vector of `n` DATA buffers (array of T) and an OPTIONAL vector of `n` META buffers (array of `uint8_t`). A meta buffer corresponds to a data buffer. Every `s`-byte data element of a data buffer corresponds to an `s`-bit element of the meta buffer. A pair of data and meta elements can
represent an integer of `8*s + s`-bits Each data element points to a buffer of size `m * sizeof(T)` bytes.
Hence, each meta element points to a buffer of size `bsize = m * sizeof(T) / 8` bytes that should be an integer, i.e. `m * sizeof(T) % 8 = 0`. This condition is not difficult to achieve as a convenient `size` can be always chosen with a negligible impact on its application.