### PR TITLE
Simplify SIMD operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,7 @@ endif()
 
 # Release flags
 set(RELEASE_CXX_FLAGS
-  -O3 -DNDEBUG
+  -O3 -DNDEBUG -flto=full
 )
 foreach(flag ${RELEASE_CXX_FLAGS})
   check_cxx_compiler_flag(${flag} has_flag_${flag})

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -44,24 +44,22 @@ fi
 
 chunk_size=51200
 # for rs-fnt with different packet sizes
-word_size=2
 for word_size in 1 2; do
-    for type_size in 2 4; do
-        max_len=$((256**word_size))
-        if ((type_size>word_size)); then
-            for ec_type in rs-fnt rs-fnt-sys; do
-              for k in 16 64; do
-                for n in 32 256 1024; do
-                  if ((n<max_len)) && ((n>k)); then
-                    m=$((n-k))
-                    for pkt_size in 512; do
-                      ${bin} -e ${ec_type} -w ${word_size} -t ${type_size} -k ${k} -m ${m} -c ${chunk_size} -s ${sce_type} -g ${threads_nb} -f ${show_type} -p ${pkt_size} -n ${samples_nb}
-                    show_type=0
-                    done
-                  fi
+    type_size=$((word_size*2))
+    max_len=$((256**word_size))
+    if ((type_size>word_size)); then
+        for ec_type in rs-fnt rs-fnt-sys; do
+          for k in 16 64; do
+            for n in 32 256 1024; do
+              if ((n<max_len)) && ((n>k)); then
+                m=$((n-k))
+                for pkt_size in 32 64 128 256 512 1024; do
+                  ${bin} -e ${ec_type} -w ${word_size} -t ${type_size} -k ${k} -m ${m} -c ${chunk_size} -s ${sce_type} -g ${threads_nb} -f ${show_type} -p ${pkt_size} -n ${samples_nb}
+                show_type=0
                 done
-              done
+              fi
             done
-        fi
-    done
+          done
+        done
+    fi
 done

--- a/scripts/test_ec.sh
+++ b/scripts/test_ec.sh
@@ -174,7 +174,6 @@ do
     fec_type=$(echo $i|cut -d_ -f1)
     word_size=$(echo $i|cut -d_ -f2)
 
-    do_test enconly ${fec_type} ${word_size} 50 50 "" ""
     do_test all ${fec_type} ${word_size} 3 3 "" ""
     do_test all ${fec_type} ${word_size} 3 3 "0 1" "0"
     do_test all ${fec_type} ${word_size} 3 5 "0 1" "0"

--- a/src/quadiron_c.cpp
+++ b/src/quadiron_c.cpp
@@ -215,6 +215,16 @@ int quadiron_fnt32_decode(
     if (!res)
         return -1;
 
+    // reset metadata of data
+    for (unsigned i = 0; i < fec->n_data; i++) {
+        parities_props[i].clear();
+        uint32_t* metadata = reinterpret_cast<uint32_t*>(data[i]);
+        int ret = parities_props[i].fnt_serialize(metadata, metadata_size / 4);
+        if (ret == -1) {
+            return -1;
+        }
+    }
+
     return 0;
 }
 
@@ -262,7 +272,6 @@ int quadiron_fnt32_reconstruct(
                     return -1;
             }
             parities_vec[i] = data[i] + metadata_size;
-            data_vec[i] = data[i] + metadata_size;
         }
         for (unsigned i = 0; i < fec->n_parities; i++) {
             if (!missing_idxs[fec->n_data + i]) {

--- a/src/simd_128.h
+++ b/src/simd_128.h
@@ -40,29 +40,23 @@ typedef __m128i VecType;
 
 /* ============= Constant variable  ============ */
 
-// @note: using const leads to an lint error of initialization of 'variable'
-// with static storage duration may throw an exception that cannot be caught
+template <typename T>
+inline VecType one();
+template <>
+inline VecType one<uint16_t>()
+{
+    return _mm_set1_epi16(1);
+}
+template <>
+inline VecType one<uint32_t>()
+{
+    return _mm_set1_epi32(1);
+}
 
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType F4_U32 = _mm_set1_epi32(65537);
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType F4_MINUS_ONE_U32 = _mm_set1_epi32(65536);
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType F3_U32 = _mm_set1_epi32(257);
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType F3_MINUS_ONE_U32 = _mm_set1_epi32(256);
-
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType F3_U16 = _mm_set1_epi16(257);
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType F3_MINUS_ONE_U16 = _mm_set1_epi16(256);
-
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType ZERO = _mm_setzero_si128();
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType ONE_U16 = _mm_set1_epi16(1);
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType ONE_U32 = _mm_set1_epi32(1);
+inline VecType zero()
+{
+    return _mm_setzero_si128();
+}
 
 // NOLINTNEXTLINE(cert-err58-cpp)
 const VecType MASK8_LO = _mm_set1_epi16(0x80);
@@ -78,25 +72,25 @@ inline void store_to_mem(VecType* address, VecType reg)
     _mm_store_si128(address, reg);
 }
 
-inline VecType bit_and(VecType x, VecType y)
+inline VecType bit_and(const VecType& x, const VecType& y)
 {
     return _mm_and_si128(x, y);
 }
-inline VecType bit_xor(VecType x, VecType y)
+inline VecType bit_xor(const VecType& x, const VecType& y)
 {
     return _mm_xor_si128(x, y);
 }
-inline uint16_t msb8_mask(VecType x)
+inline uint16_t msb8_mask(const VecType& x)
 {
     return _mm_movemask_epi8(x);
 }
-inline bool and_is_zero(VecType x, VecType y)
+inline bool and_is_zero(const VecType& x, const VecType& y)
 {
     return _mm_testz_si128(x, y);
 }
-inline bool is_zero(VecType x)
+inline bool is_zero(const VecType& x)
 {
-    return _mm_testc_si128(ZERO, x);
+    return _mm_testc_si128(zero(), x);
 }
 
 #define SHIFTR(x, imm8) (_mm_srli_si128(x, imm8))
@@ -119,66 +113,66 @@ inline VecType set_one(uint16_t val)
 }
 
 template <typename T>
-inline VecType add(VecType x, VecType y);
+inline VecType add(const VecType& x, const VecType& y);
 template <>
-inline VecType add<uint32_t>(VecType x, VecType y)
+inline VecType add<uint32_t>(const VecType& x, const VecType& y)
 {
     return _mm_add_epi32(x, y);
 }
 template <>
-inline VecType add<uint16_t>(VecType x, VecType y)
+inline VecType add<uint16_t>(const VecType& x, const VecType& y)
 {
     return _mm_add_epi16(x, y);
 }
 
 template <typename T>
-inline VecType sub(VecType x, VecType y);
+inline VecType sub(const VecType& x, const VecType& y);
 template <>
-inline VecType sub<uint32_t>(VecType x, VecType y)
+inline VecType sub<uint32_t>(const VecType& x, const VecType& y)
 {
     return _mm_sub_epi32(x, y);
 }
 template <>
-inline VecType sub<uint16_t>(VecType x, VecType y)
+inline VecType sub<uint16_t>(const VecType& x, const VecType& y)
 {
     return _mm_sub_epi16(x, y);
 }
 
 template <typename T>
-inline VecType mul(VecType x, VecType y);
+inline VecType mul(const VecType& x, const VecType& y);
 template <>
-inline VecType mul<uint32_t>(VecType x, VecType y)
+inline VecType mul<uint32_t>(const VecType& x, const VecType& y)
 {
     return _mm_mullo_epi32(x, y);
 }
 template <>
-inline VecType mul<uint16_t>(VecType x, VecType y)
+inline VecType mul<uint16_t>(const VecType& x, const VecType& y)
 {
     return _mm_mullo_epi16(x, y);
 }
 
 template <typename T>
-inline VecType compare_eq(VecType x, VecType y);
+inline VecType compare_eq(const VecType& x, const VecType& y);
 template <>
-inline VecType compare_eq<uint32_t>(VecType x, VecType y)
+inline VecType compare_eq<uint32_t>(const VecType& x, const VecType& y)
 {
     return _mm_cmpeq_epi32(x, y);
 }
 template <>
-inline VecType compare_eq<uint16_t>(VecType x, VecType y)
+inline VecType compare_eq<uint16_t>(const VecType& x, const VecType& y)
 {
     return _mm_cmpeq_epi16(x, y);
 }
 
 template <typename T>
-inline VecType min(VecType x, VecType y);
+inline VecType min(const VecType& x, const VecType& y);
 template <>
-inline VecType min<uint32_t>(VecType x, VecType y)
+inline VecType min<uint32_t>(const VecType& x, const VecType& y)
 {
     return _mm_min_epu32(x, y);
 }
 template <>
-inline VecType min<uint16_t>(VecType x, VecType y)
+inline VecType min<uint16_t>(const VecType& x, const VecType& y)
 {
     return _mm_min_epu16(x, y);
 }

--- a/src/simd_256.h
+++ b/src/simd_256.h
@@ -53,29 +53,23 @@ typedef __m128i HalfVecType;
 
 /* ============= Constant variable  ============ */
 
-// @note: using const leads to an lint error of initialization of 'variable'
-// with static storage duration may throw an exception that cannot be caught
+template <typename T>
+inline VecType one();
+template <>
+inline VecType one<uint16_t>()
+{
+    return _mm256_set1_epi16(1);
+}
+template <>
+inline VecType one<uint32_t>()
+{
+    return _mm256_set1_epi32(1);
+}
 
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType F4_U32 = _mm256_set1_epi32(65537);
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType F4_MINUS_ONE_U32 = _mm256_set1_epi32(65536);
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType F3_U32 = _mm256_set1_epi32(257);
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType F3_MINUS_ONE_U32 = _mm256_set1_epi32(256);
-
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType F3_U16 = _mm256_set1_epi16(257);
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType F3_MINUS_ONE_U16 = _mm256_set1_epi16(256);
-
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType ZERO = _mm256_setzero_si256();
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType ONE_U16 = _mm256_set1_epi16(1);
-// NOLINTNEXTLINE(cert-err58-cpp)
-const VecType ONE_U32 = _mm256_set1_epi32(1);
+inline VecType zero()
+{
+    return _mm256_setzero_si256();
+}
 
 // NOLINTNEXTLINE(cert-err58-cpp)
 const VecType MASK8_LO = _mm256_set1_epi16(0x80);
@@ -86,30 +80,30 @@ inline VecType load_to_reg(VecType* address)
 {
     return _mm256_load_si256(address);
 }
-inline void store_to_mem(VecType* address, VecType reg)
+inline void store_to_mem(VecType* address, const VecType& reg)
 {
     _mm256_store_si256(address, reg);
 }
 
-inline VecType bit_and(VecType x, VecType y)
+inline VecType bit_and(const VecType& x, const VecType& y)
 {
     return _mm256_and_si256(x, y);
 }
-inline VecType bit_xor(VecType x, VecType y)
+inline VecType bit_xor(const VecType& x, const VecType& y)
 {
     return _mm256_xor_si256(x, y);
 }
-inline uint32_t msb8_mask(VecType x)
+inline uint32_t msb8_mask(const VecType& x)
 {
     return _mm256_movemask_epi8(x);
 }
-inline bool and_is_zero(VecType x, VecType y)
+inline bool and_is_zero(const VecType& x, const VecType& y)
 {
     return _mm256_testz_si256(x, y);
 }
-inline bool is_zero(VecType x)
+inline bool is_zero(const VecType& x)
 {
-    return _mm256_testc_si256(ZERO, x);
+    return _mm256_testc_si256(zero(), x);
 }
 
 #define SHIFTR(x, imm8) (_mm256_srli_si256(x, imm8))
@@ -132,66 +126,66 @@ inline VecType set_one(uint16_t val)
 }
 
 template <typename T>
-inline VecType add(VecType x, VecType y);
+inline VecType add(const VecType& x, const VecType& y);
 template <>
-inline VecType add<uint32_t>(VecType x, VecType y)
+inline VecType add<uint32_t>(const VecType& x, const VecType& y)
 {
     return _mm256_add_epi32(x, y);
 }
 template <>
-inline VecType add<uint16_t>(VecType x, VecType y)
+inline VecType add<uint16_t>(const VecType& x, const VecType& y)
 {
     return _mm256_add_epi16(x, y);
 }
 
 template <typename T>
-inline VecType sub(VecType x, VecType y);
+inline VecType sub(const VecType& x, const VecType& y);
 template <>
-inline VecType sub<uint32_t>(VecType x, VecType y)
+inline VecType sub<uint32_t>(const VecType& x, const VecType& y)
 {
     return _mm256_sub_epi32(x, y);
 }
 template <>
-inline VecType sub<uint16_t>(VecType x, VecType y)
+inline VecType sub<uint16_t>(const VecType& x, const VecType& y)
 {
     return _mm256_sub_epi16(x, y);
 }
 
 template <typename T>
-inline VecType mul(VecType x, VecType y);
+inline VecType mul(const VecType& x, const VecType& y);
 template <>
-inline VecType mul<uint32_t>(VecType x, VecType y)
+inline VecType mul<uint32_t>(const VecType& x, const VecType& y)
 {
     return _mm256_mullo_epi32(x, y);
 }
 template <>
-inline VecType mul<uint16_t>(VecType x, VecType y)
+inline VecType mul<uint16_t>(const VecType& x, const VecType& y)
 {
     return _mm256_mullo_epi16(x, y);
 }
 
 template <typename T>
-inline VecType compare_eq(VecType x, VecType y);
+inline VecType compare_eq(const VecType& x, const VecType& y);
 template <>
-inline VecType compare_eq<uint32_t>(VecType x, VecType y)
+inline VecType compare_eq<uint32_t>(const VecType& x, const VecType& y)
 {
     return _mm256_cmpeq_epi32(x, y);
 }
 template <>
-inline VecType compare_eq<uint16_t>(VecType x, VecType y)
+inline VecType compare_eq<uint16_t>(const VecType& x, const VecType& y)
 {
     return _mm256_cmpeq_epi16(x, y);
 }
 
 template <typename T>
-inline VecType min(VecType x, VecType y);
+inline VecType min(const VecType& x, const VecType& y);
 template <>
-inline VecType min<uint32_t>(VecType x, VecType y)
+inline VecType min<uint32_t>(const VecType& x, const VecType& y)
 {
     return _mm256_min_epu32(x, y);
 }
 template <>
-inline VecType min<uint16_t>(VecType x, VecType y)
+inline VecType min<uint16_t>(const VecType& x, const VecType& y)
 {
     return _mm256_min_epu16(x, y);
 }

--- a/src/simd_nf4.h
+++ b/src/simd_nf4.h
@@ -180,7 +180,7 @@ inline __uint128_t add(__uint128_t a, __uint128_t b)
     HalfVecType res;
     VecType vec_a = load_to_reg(a);
     VecType vec_b = load_to_reg(b);
-    store_low_half_to_mem(&res, mod_add(vec_a, vec_b, F4));
+    store_low_half_to_mem(&res, mod_add<uint32_t>(vec_a, vec_b));
     return reinterpret_cast<__uint128_t>(res);
 }
 
@@ -189,7 +189,7 @@ inline __uint128_t sub(__uint128_t a, __uint128_t b)
     HalfVecType res;
     VecType vec_a = load_to_reg(a);
     VecType vec_b = load_to_reg(b);
-    store_low_half_to_mem(&res, mod_sub(vec_a, vec_b, F4));
+    store_low_half_to_mem(&res, mod_sub<uint32_t>(vec_a, vec_b));
     return reinterpret_cast<__uint128_t>(res);
 }
 
@@ -198,7 +198,7 @@ inline __uint128_t mul(__uint128_t a, __uint128_t b)
     HalfVecType res;
     VecType vec_a = load_to_reg(a);
     VecType vec_b = load_to_reg(b);
-    store_low_half_to_mem(&res, mod_mul_safe(vec_a, vec_b, F4));
+    store_low_half_to_mem(&res, mod_mul_safe<uint32_t>(vec_a, vec_b));
     return reinterpret_cast<__uint128_t>(res);
 }
 
@@ -217,8 +217,8 @@ inline void add_buf_to_two_bufs_rem(
         VecType _x_next_p = load_to_reg(_x_half[i]);
         VecType _y_p = load_to_reg(_y[i]);
 
-        store_low_half_to_mem(_x + i, mod_add(_x_p, _y_p, F4));
-        store_low_half_to_mem(_x_half + i, mod_add(_x_next_p, _y_p, F4));
+        store_low_half_to_mem(_x + i, mod_add<uint32_t>(_x_p, _y_p));
+        store_low_half_to_mem(_x_half + i, mod_add<uint32_t>(_x_next_p, _y_p));
     }
 }
 
@@ -230,7 +230,7 @@ inline void hadamard_mul_rem(unsigned n, __uint128_t* x, __uint128_t* y)
         VecType _x_p = load_to_reg(_x[i]);
         VecType _y_p = load_to_reg(_y[i]);
 
-        store_low_half_to_mem(_x + i, mod_mul_safe(_x_p, _y_p, F4));
+        store_low_half_to_mem(_x + i, mod_mul_safe<uint32_t>(_x_p, _y_p));
     }
 }
 
@@ -248,8 +248,9 @@ inline void hadamard_mul_doubled_rem(
         VecType _x_next_p = load_to_reg(_x_half[i]);
         VecType _y_p = load_to_reg(_y[i]);
 
-        store_low_half_to_mem(_x + i, mod_mul_safe(_x_p, _y_p, F4));
-        store_low_half_to_mem(_x_half + i, mod_mul_safe(_x_next_p, _y_p, F4));
+        store_low_half_to_mem(_x + i, mod_mul_safe<uint32_t>(_x_p, _y_p));
+        store_low_half_to_mem(
+            _x_half + i, mod_mul_safe<uint32_t>(_x_next_p, _y_p));
     }
 }
 
@@ -266,7 +267,7 @@ inline __uint128_t add(__uint128_t a, __uint128_t b)
     VecType res;
     VecType vec_a = load_to_reg(a);
     VecType vec_b = load_to_reg(b);
-    store_to_mem(&res, mod_add(vec_a, vec_b, F4));
+    store_to_mem(&res, mod_add<uint32_t>(vec_a, vec_b));
     return reinterpret_cast<__uint128_t>(res);
 }
 
@@ -275,7 +276,7 @@ inline __uint128_t sub(__uint128_t a, __uint128_t b)
     VecType res;
     VecType vec_a = load_to_reg(a);
     VecType vec_b = load_to_reg(b);
-    store_to_mem(&res, mod_sub(vec_a, vec_b, F4));
+    store_to_mem(&res, mod_sub<uint32_t>(vec_a, vec_b));
     return reinterpret_cast<__uint128_t>(res);
 }
 
@@ -284,7 +285,7 @@ inline __uint128_t mul(__uint128_t a, __uint128_t b)
     VecType res;
     VecType vec_a = load_to_reg(a);
     VecType vec_b = load_to_reg(b);
-    store_to_mem(&res, mod_mul_safe(vec_a, vec_b, F4));
+    store_to_mem(&res, mod_mul_safe<uint32_t>(vec_a, vec_b));
     return reinterpret_cast<__uint128_t>(res);
 }
 
@@ -327,12 +328,12 @@ inline void add_buf_to_two_bufs(unsigned n, __uint128_t* _x, __uint128_t* _y)
 
     // add y to the first half of `x`
     for (i = 0; i < vec_len; ++i) {
-        x[i] = mod_add(x[i], y[i], F4);
+        x[i] = mod_add<uint32_t>(x[i], y[i]);
     }
 
     // add y to the second half of `x`
     for (i = 0; i < vec_len; ++i) {
-        x_next[i] = mod_add(x_next[i], y[i], F4);
+        x_next[i] = mod_add<uint32_t>(x_next[i], y[i]);
     }
 
     if (rem_len > 0) {
@@ -354,7 +355,7 @@ inline void hadamard_mul(unsigned n, __uint128_t* _x, __uint128_t* _y)
 
     // multiply y to the first half of `x`
     for (i = 0; i < vec_len; ++i) {
-        x[i] = mod_mul_safe(x[i], y[i], F4);
+        x[i] = mod_mul_safe<uint32_t>(x[i], y[i]);
     }
 
     if (rem_len > 0) {

--- a/src/simd_ring.h
+++ b/src/simd_ring.h
@@ -56,13 +56,13 @@ inline void mul_coef_to_buf(const T a, T* src, T* dest, size_t len, T card)
     size_t i = 0;
     const size_t end = (_len > 3) ? _len - 3 : 0;
     for (; i < end; i += 4) {
-        _dest[i] = mod_mul(coef, _src[i], card);
-        _dest[i + 1] = mod_mul(coef, _src[i + 1], card);
-        _dest[i + 2] = mod_mul(coef, _src[i + 2], card);
-        _dest[i + 3] = mod_mul(coef, _src[i + 3], card);
+        _dest[i] = mod_mul<T>(coef, _src[i]);
+        _dest[i + 1] = mod_mul<T>(coef, _src[i + 1]);
+        _dest[i + 2] = mod_mul<T>(coef, _src[i + 2]);
+        _dest[i + 3] = mod_mul<T>(coef, _src[i + 3]);
     }
     for (; i < _len; ++i) {
-        _dest[i] = mod_mul(coef, _src[i], card);
+        _dest[i] = mod_mul<T>(coef, _src[i]);
     }
 
     if (_last_len > 0) {
@@ -84,7 +84,7 @@ inline void add_two_bufs(T* src, T* dest, size_t len, T card)
 
     size_t i;
     for (i = 0; i < _len; i++) {
-        _dest[i] = mod_add(_src[i], _dest[i], card);
+        _dest[i] = mod_add<T>(_src[i], _dest[i]);
     }
     if (_last_len > 0) {
         for (i = _len * ratio; i < len; i++) {
@@ -107,7 +107,7 @@ inline void sub_two_bufs(T* bufa, T* bufb, T* res, size_t len, T card)
     size_t i;
     for (i = 0; i < _len; i++) {
         // perform subtraction
-        _res[i] = mod_sub(_bufa[i], _bufb[i], card);
+        _res[i] = mod_sub<T>(_bufa[i], _bufb[i]);
     }
     if (_last_len > 0) {
         for (i = _len * ratio; i < len; i++) {
@@ -133,7 +133,7 @@ inline void mul_two_bufs(T* src, T* dest, size_t len, T card)
     size_t i;
     for (i = 0; i < _len; i++) {
         // perform multiplicaton
-        _dest[i] = mod_mul_safe(_src[i], _dest[i], card);
+        _dest[i] = mod_mul_safe<T>(_src[i], _dest[i]);
     }
     if (_last_len > 0) {
         for (i = _len * ratio; i < len; i++) {
@@ -155,7 +155,7 @@ inline void neg(size_t len, T* buf, T card)
 
     size_t i;
     for (i = 0; i < _len; i++) {
-        _buf[i] = mod_neg(_buf[i], card);
+        _buf[i] = mod_neg<T>(_buf[i]);
     }
     if (_last_len > 0) {
         for (i = _len * ratio; i < len; i++) {

--- a/test/ec_driver.cpp
+++ b/test/ec_driver.cpp
@@ -52,6 +52,13 @@ static void xusage()
 }
 
 [[noreturn]]
+static void xfnt_bad_word_size()
+{
+    std::cerr << "FEC using FNT supports word_size = 1 or 2\n";
+    std::exit(EXIT_FAILURE);
+}
+
+[[noreturn]]
 static void xperror(const char* str)
 {
     std::cerr << str << "\n";
@@ -582,36 +589,46 @@ int main(int argc, char** argv)
     data_zpad = count_digits(n_data - 1);
 
     if (eflag == EC_TYPE_RS_FNT) {
-        if (word_size <= 4) {
+        switch (word_size) {
+        case 1:
+            run_fec_rs_fnt<uint16_t>(
+                word_size,
+                n_data,
+                n_parities,
+                rflag,
+                quadiron::fec::FecType::NON_SYSTEMATIC);
+            break;
+        case 2:
             run_fec_rs_fnt<uint32_t>(
                 word_size,
                 n_data,
                 n_parities,
                 rflag,
                 quadiron::fec::FecType::NON_SYSTEMATIC);
-        } else if (word_size <= 8) {
-            run_fec_rs_fnt<uint64_t>(
-                word_size,
-                n_data,
-                n_parities,
-                rflag,
-                quadiron::fec::FecType::NON_SYSTEMATIC);
+            break;
+        default:
+            xfnt_bad_word_size();
         }
     } else if (eflag == EC_TYPE_RS_FNT_SYS) {
-        if (word_size <= 4) {
+        switch (word_size) {
+        case 1:
+            run_fec_rs_fnt<uint16_t>(
+                word_size,
+                n_data,
+                n_parities,
+                rflag,
+                quadiron::fec::FecType::SYSTEMATIC);
+            break;
+        case 2:
             run_fec_rs_fnt<uint32_t>(
                 word_size,
                 n_data,
                 n_parities,
                 rflag,
                 quadiron::fec::FecType::SYSTEMATIC);
-        } else if (word_size <= 8) {
-            run_fec_rs_fnt<uint64_t>(
-                word_size,
-                n_data,
-                n_parities,
-                rflag,
-                quadiron::fec::FecType::SYSTEMATIC);
+            break;
+        default:
+            xfnt_bad_word_size();
         }
     } else if (eflag == EC_TYPE_RS_NF4) {
         if (word_size <= 2) {

--- a/test/fec_utest.cpp
+++ b/test/fec_utest.cpp
@@ -130,42 +130,41 @@ TYPED_TEST(FecTestCommon, TestGf2nFftAdd) // NOLINT
 }
 
 template <typename T>
+class FecTestFnt : public FecTestCommon<T> {
+};
+
+using FntType = ::testing::Types<uint16_t, uint32_t>;
+TYPED_TEST_CASE(FecTestFnt, FntType);
+
+TYPED_TEST(FecTestFnt, TestFnt) // NOLINT
+{
+    const size_t word_size = sizeof(TypeParam) / 2;
+    fec::RsFnt<TypeParam> fec(
+        fec::FecType::NON_SYSTEMATIC,
+        word_size,
+        this->n_data,
+        this->n_parities);
+    this->run_test(fec, true);
+}
+
+TYPED_TEST(FecTestFnt, TestFntSys) // NOLINT
+{
+    const size_t word_size = sizeof(TypeParam) / 2;
+    fec::RsFnt<TypeParam> fec(
+        fec::FecType::SYSTEMATIC, word_size, this->n_data, this->n_parities);
+    this->run_test(fec, true);
+}
+
+template <typename T>
 class FecTestNo128 : public FecTestCommon<T> {
 };
 
-using No128 = ::testing::Types<uint32_t, uint64_t>;
+using No128 = ::testing::Types<uint16_t, uint32_t, uint64_t>;
 TYPED_TEST_CASE(FecTestNo128, No128);
-
-TYPED_TEST(FecTestNo128, TestFnt) // NOLINT
-{
-    for (unsigned word_size = 1; word_size <= 2; ++word_size) {
-        fec::RsFnt<TypeParam> fec(
-            fec::FecType::NON_SYSTEMATIC,
-            word_size,
-            this->n_data,
-            this->n_parities);
-        this->run_test(fec, true);
-    }
-}
-
-TYPED_TEST(FecTestNo128, TestFntSys) // NOLINT
-{
-    for (unsigned word_size = 1; word_size <= 2; ++word_size) {
-        fec::RsFnt<TypeParam> fec(
-            fec::FecType::SYSTEMATIC,
-            word_size,
-            this->n_data,
-            this->n_parities);
-        this->run_test(fec, true);
-    }
-}
 
 TYPED_TEST(FecTestNo128, TestGfpFft) // NOLINT
 {
-    for (size_t word_size = 1; word_size <= 4 && word_size < sizeof(TypeParam);
-         word_size *= 2) {
-        fec::RsGfpFft<TypeParam> fec(word_size, this->n_data, this->n_parities);
-
-        this->run_test(fec, true);
-    }
+    const size_t word_size = sizeof(TypeParam) / 2;
+    fec::RsGfpFft<TypeParam> fec(word_size, this->n_data, this->n_parities);
+    this->run_test(fec, true);
 }


### PR DESCRIPTION
NB: the PR is split/extracted from the big one #282 

The purpose is to eliminate as much as possible branches, particularly in essential operations s.t. modular operations.

Currently, we support vectorized operations of FNT in the cases:
- FNT(257) using `uint16_t` and `uint32_t`
- FNT(65537) using `uint32_t`

But the support of FNT(257) using `uint32_t` raises additional branches of checking the cardinal of the field. And its encoding/decoding speeds are obviously smaller than the two other cases: FNT(257) using `uin16_t` and FNT(65537) using `uint32_t`.

Hence, for FNT, we support only  FNT(257) using `uin16_t` and FNT(65537) using `uint32_t`.